### PR TITLE
enable redux devtools in non-production

### DIFF
--- a/frontend/public/redux.js
+++ b/frontend/public/redux.js
@@ -1,4 +1,4 @@
-import { applyMiddleware, combineReducers, createStore } from 'redux';
+import { applyMiddleware, combineReducers, createStore, compose } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import thunk from 'redux-thunk';
 
@@ -6,6 +6,12 @@ import { featureReducer, featureReducerName } from './features';
 import { monitoringReducer, monitoringReducerName } from './monitoring';
 import k8sReducers from './module/k8s/k8s-reducers';
 import UIReducers from './ui/ui-reducers';
+
+const composeEnhancers =
+  // eslint-disable-next-line no-undef
+  (process.env.NODE_ENV !== 'production' &&
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) ||
+  compose;
 
 const reducers = combineReducers({
   k8s: k8sReducers, // data
@@ -15,7 +21,7 @@ const reducers = combineReducers({
   [monitoringReducerName]: monitoringReducer,
 });
 
-const store = createStore(reducers, {}, applyMiddleware(thunk));
+const store = createStore(reducers, {}, composeEnhancers(applyMiddleware(thunk)));
 export default store;
 
 // eslint-disable-next-line no-undef


### PR DESCRIPTION
Support for redux devtools in non-production mode as per the setup guidelines:
https://github.com/zalmoxisus/redux-devtools-extension