### PR TITLE
feat(perspective-switcher):Add tests for DevConsoleNav Component

### DIFF
--- a/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
+++ b/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
@@ -13,7 +13,7 @@ interface DevConsoleNavigationProps {
 
 const DevNavSection = NavSection as React.ComponentClass<any>;
 
-const PageNav = (props: DevConsoleNavigationProps) => {
+export const PageNav = (props: DevConsoleNavigationProps) => {
   const isActive = (path: string) => {
     return props.location.endsWith(path);
   };
@@ -62,7 +62,7 @@ const PageNav = (props: DevConsoleNavigationProps) => {
   );
 };
 
-const DevConsoleNavigation: React.FunctionComponent<DevConsoleNavigationProps> = (
+export const DevConsoleNavigation: React.FunctionComponent<DevConsoleNavigationProps> = (
   props: DevConsoleNavigationProps,
 ) => {
   return <PageSidebar nav={<PageNav {...props} />} isNavOpen={props.isNavOpen} />;

--- a/frontend/public/extend/devconsole/components/__tests__/DevConsoleNav.spec.tsx
+++ b/frontend/public/extend/devconsole/components/__tests__/DevConsoleNav.spec.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable no-unused-vars */
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { PageSidebar } from '@patternfly/react-core';
+import { DevConsoleNavigation, PageNav} from '../DevConsoleNav';
+
+function shallowSetup() {
+  const props = {
+    location : '/devops',
+    isNavOpen : true,
+    onNavSelect : () => {},
+    onToggle : () => {},
+  };
+
+  const navWrapper = shallow(<DevConsoleNavigation {...props} />);
+
+  return {
+    navWrapper,
+    props,
+  };
+}
+
+describe('DevConsole Navigation', () => {
+  it('renders `DevConsoleNavigation` component using the given props', () => {
+    const { navWrapper, props } = shallowSetup();
+    expect(navWrapper.exists()).toBe(true);
+    expect(navWrapper.find(PageSidebar).exists());
+    expect(navWrapper.find(PageSidebar).length).toEqual(1);
+    expect(navWrapper.find(PageSidebar).prop('isNavOpen')).toEqual(true);
+    expect(navWrapper.find(PageSidebar).dive().find(PageNav).prop('onToggle')).toEqual(props.onToggle);
+    expect(navWrapper.find(PageSidebar).dive().find(PageNav).prop('onNavSelect')).toEqual(props.onNavSelect);
+  });
+
+  it('allows us to set Props', () => {
+    const { navWrapper } = shallowSetup();
+    expect(navWrapper.find(PageSidebar).props().isNavOpen).toEqual(true);
+    navWrapper.setProps(
+      {
+        isNavOpen: false,
+      });
+    expect(navWrapper.find(PageSidebar).props().isNavOpen).toEqual(false);
+    expect(navWrapper.find(PageSidebar).dive().find(PageNav).props().location).toEqual('/devops');
+    navWrapper.setProps(
+      {
+        location: '/devops/codebases',
+      });
+    expect(navWrapper.find(PageSidebar).dive().find(PageNav).props().location).toEqual('/devops/codebases');
+  });
+});


### PR DESCRIPTION
With an intension to test just the DevConsoleNavigation component, without worrying about the Redux Store, I have made minor changes to the component's logic.