### PR TITLE
add crds mocks resources for dev environment

### DIFF
--- a/frontend/devconsole.sh
+++ b/frontend/devconsole.sh
@@ -14,3 +14,10 @@ else
    oc create -f http://operator-hub-shbose-preview1-stage.b542.starter-us-east-2a.openshiftapps.com/install/devopsconsole.v0.1.0.yaml
 
 fi
+
+MOCKS_DIR=($PWD/public/extend/devconsole/__mocks__)
+if [ -n "$(ls -A $MOCKS_DIR 2>/dev/null)" ]
+then
+  echo -e "Adding mock crds...\n"
+  oc apply -f $MOCKS_DIR --recursive || true
+fi

--- a/frontend/public/extend/devconsole/__mocks__/crds/pipleline.yaml
+++ b/frontend/public/extend/devconsole/__mocks__/crds/pipleline.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: pipelines.devopsconsole.openshift.io
+spec:
+  group: devopsconsole.openshift.io
+  names:
+    kind: Pipeline
+    listKind: PipelineList
+    plural: pipelines
+    singular: pipeline
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+          namespace: string
+        spec:
+          properties:
+            app:
+              type: "string"
+              minimum: 1
+            codebase:
+              type: "string"
+              minimum: 1
+            buildtype:
+              type: "string"
+              minimum: 1 
+            listenport:
+              type: "number"
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true 

--- a/frontend/public/extend/devconsole/__mocks__/crds/pipleline.yaml
+++ b/frontend/public/extend/devconsole/__mocks__/crds/pipleline.yaml
@@ -2,14 +2,14 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: pipelines.devopsconsole.openshift.io
+  name: mockpipelines.devopsconsole.openshift.io
 spec:
   group: devopsconsole.openshift.io
   names:
-    kind: Pipeline
-    listKind: PipelineList
-    plural: pipelines
-    singular: pipeline
+    kind: MockPipeline
+    listKind: MockPipelineList
+    plural: mockpipelines
+    singular: mockpipeline
   scope: Namespaced
   subresources:
     status: {}

--- a/frontend/public/extend/devconsole/__mocks__/resources/pipeline-resource.yaml
+++ b/frontend/public/extend/devconsole/__mocks__/resources/pipeline-resource.yaml
@@ -1,5 +1,5 @@
 apiVersion: devopsconsole.openshift.io/v1alpha1
-kind: Pipeline
+kind: MockPipeline
 metadata:
   name: pipeline-1
 spec:
@@ -10,7 +10,7 @@ spec:
   listenport: 9000
 ---
 apiVersion: devopsconsole.openshift.io/v1alpha1
-kind: Pipeline
+kind: MockPipeline
 metadata:
   name: pipeline-2
 spec:
@@ -21,7 +21,7 @@ spec:
   listenport: 9000
 ---
 apiVersion: devopsconsole.openshift.io/v1alpha1
-kind: Pipeline
+kind: MockPipeline
 metadata:
   name: pipeline-3
 spec:

--- a/frontend/public/extend/devconsole/__mocks__/resources/pipeline-resource.yaml
+++ b/frontend/public/extend/devconsole/__mocks__/resources/pipeline-resource.yaml
@@ -1,0 +1,32 @@
+apiVersion: devopsconsole.openshift.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline-1
+spec:
+  # Add fields here
+  app: "myproject"
+  buildtype: "react"
+  codebase: "https://github.com/sbose78/nodejs-rest-http-crud"
+  listenport: 9000
+---
+apiVersion: devopsconsole.openshift.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline-2
+spec:
+  # Add fields here
+  app: "myproject"
+  buildtype: "react"
+  codebase: "https://github.com/sbose78/nodejs-rest-http-crud"
+  listenport: 9000
+---
+apiVersion: devopsconsole.openshift.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline-3
+spec:
+  # Add fields here
+  app: "myproject"
+  buildtype: "react"
+  codebase: "https://github.com/sbose78/nodejs-rest-http-crud"
+  listenport: 9000


### PR DESCRIPTION
On running `yarn devconsole`, all the yaml files inside __mocks__/ directory will be used to create mock crds and resource objects for local development purpose.

Directory structure
`__mocks__/`
  - crds ( contains all the custom resource definition yaml files)
  - resources ( contains multiple grouped resource object files)