### PR TITLE
Updated devconsole script to use oc api-versions

### DIFF
--- a/frontend/devconsole.sh
+++ b/frontend/devconsole.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
-DEVCONSOLE_OPERATORS_INSTALLED=$(oc get pods --all-namespaces --output=json | jq '[.items | .[].metadata.name  | contains("devops")] | any')
-DEVCONSOLE_CRDS_INSTALLED=$(oc get crds --output=json | jq '[.items | .[].metadata.name  | contains("gitsources.devopsconsole.openshift.io")] | any')
+DEVCONSOLE_OPERATORS_INSTALLED=$(oc get csv --output=json | jq '[.items | .[].metadata.name  | contains("devconsole")] | any')
 
-if  $DEVCONSOLE_OPERATORS_INSTALLED && $DEVCONSOLE_CRDS_INSTALLED
+if  $DEVCONSOLE_OPERATORS_INSTALLED
 then
-   echo -e "\n\033[0;32m \xE2\x9C\x94 Devconsole Operator and crds are already installed \033[0m\n"
+   echo -e "\n\033[0;32m \xE2\x9C\x94 Devconsole Operator is already installed \033[0m\n"
 else
 
    echo -e "Installing OLM... \n"
    oc create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
    echo -e "\n Installing DevConsole Operator... \n"
-   oc create -f http://operator-hub-shbose-preview1-stage.b542.starter-us-east-2a.openshiftapps.com/install/devopsconsole.v0.1.0.yaml
+   oc create -f http://operator-hub-shbose-preview1-stage.b542.starter-us-east-2a.openshiftapps.com/install/devconsole.v0.1.0.yaml
 
 fi

--- a/frontend/devconsole.sh
+++ b/frontend/devconsole.sh
@@ -1,15 +1,35 @@
 #!/usr/bin/env bash
 
-DEVCONSOLE_OPERATORS_INSTALLED=$(oc get csv --output=json | jq '[.items | .[].metadata.name  | contains("devconsole")] | any')
-
-if  $DEVCONSOLE_OPERATORS_INSTALLED
-then
+if  oc api-versions | grep -q 'devconsole.openshift.io'; then
    echo -e "\n\033[0;32m \xE2\x9C\x94 Devconsole Operator is already installed \033[0m\n"
 else
-
-   echo -e "Installing OLM... \n"
-   oc create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
-   echo -e "\n Installing DevConsole Operator... \n"
-   oc create -f http://operator-hub-shbose-preview1-stage.b542.starter-us-east-2a.openshiftapps.com/install/devconsole.v0.1.0.yaml
-
+  echo -e "Which openshift version are you running (Ex - 3.x, 4.x)?"
+  read OPENSHIFT_VERSION
+  case $OPENSHIFT_VERSION in
+    3.x)
+      echo -e "Running Openshift Version 3.x \n"
+      echo -e "Installing OLM... \n"
+      oc apply -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
+      echo -e "\n Installing DevConsole Operator... \n"
+      echo -e "\n Installing Catalog Source... \n"
+      oc apply -f ./public/extend/devconsole/shared/yamls/catalog_source3.yaml
+      echo -e "\n Waiting for 15s for catalog source to get installed before creating subscription \n"
+      sleep 15s
+      echo -e "\n Creating Subscription... \n"
+      oc apply -f ./public/extend/devconsole/shared/yamls/subscription3.yaml
+      ;;
+    4.x)
+      echo -e "Running Openshift Version 4.x \n"
+      echo -e "\n Installing DevConsole Operator... \n"
+      echo -e "\n Installing Catalog Source... \n"
+      oc apply -f ./public/extend/devconsole/shared/yamls/catalog_source4.yaml
+      echo -e "\n Waiting for 15s for catalog source to get installed before creating subscription \n"
+      sleep 15s
+      echo -e "\n Creating Subscription... \n"
+      oc apply -f ./public/extend/devconsole/shared/yamls/subscription4.yaml
+      ;;
+    *)
+      echo -e "We do not support the given version \n"
+      ;;
+  esac
 fi

--- a/frontend/public/extend/devconsole/shared/yamls/catalog_source3.yaml
+++ b/frontend/public/extend/devconsole/shared/yamls/catalog_source3.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1 
+kind: CatalogSource
+metadata: 
+  name: rhd-operatorhub-catalog 
+  namespace: olm 
+spec: 
+  sourceType: grpc
+  image: quay.io/redhat-developer/operator-registry:latest
+  displayName: Community Operators
+  publisher: RHD Operator Hub 

--- a/frontend/public/extend/devconsole/shared/yamls/catalog_source4.yaml
+++ b/frontend/public/extend/devconsole/shared/yamls/catalog_source4.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: rhd-operatorhub-catalog
+  namespace: openshift-operator-lifecycle-manager
+spec:
+  sourceType: grpc
+  image: quay.io/redhat-developer/operator-registry:latest
+  displayName: Community Operators
+  publisher: RHD Operator Hub

--- a/frontend/public/extend/devconsole/shared/yamls/subscription3.yaml
+++ b/frontend/public/extend/devconsole/shared/yamls/subscription3.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: my-devconsole
+  namespace: operators
+spec:
+  channel: alpha
+  name: devconsole
+  source: rhd-operatorhub-catalog
+  sourceNamespace: olm

--- a/frontend/public/extend/devconsole/shared/yamls/subscription4.yaml
+++ b/frontend/public/extend/devconsole/shared/yamls/subscription4.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: my-devconsole
+  namespace: openshift-operators
+spec:
+  channel: alpha
+  name: devconsole
+  source: rhd-operatorhub-catalog
+  sourceNamespace: openshift-operator-lifecycle-manager

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -194,7 +194,7 @@ const detectUser = dispatch => coFetchJSON('api/kubernetes/apis/user.openshift.i
     },
   );
 
-const devopsConsolePath = `${k8sBasePath}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/gitsources.devopsconsole.openshift.io`;
+const devopsConsolePath = `${k8sBasePath}/apis/devconsole.openshift.io`;
 const detectDevConsole = dispatch => {
   coFetchJSON(devopsConsolePath)
     .then(


### PR DESCRIPTION
For a normal openshift user `oc get crds` fail because of not having enough permissions. So, changing the the script to use `oc get csv` instead to check for installed operator.

Also, updated the devconsole operator to the latest version. 