### PR TITLE
Fix links for empty state, create application,  service instance and nav typo

### DIFF
--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -6,6 +6,8 @@ import { NamespaceModel, ProjectRequestModel, NetworkPolicyModel } from '../../m
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
 import { Dropdown, history, PromiseComponent, resourceObjPath, SelectorInput } from '../utils';
 import { FLAGS, setFlag } from '../../features';
+import { getActivePerspective } from '../../ui/ui-selectors';
+import { pathWithPerspective } from '../utils/perspective';
 
 const allow = 'allow';
 const deny = 'deny';
@@ -18,11 +20,17 @@ const defaultDeny = {
   },
 };
 
+const mapStateToProps = state => {
+  return {
+    activePerspective: getActivePerspective(state),
+  };
+};
+
 const mapDispatchToProps = dispatch => ({
   hideStartGuide: () => setFlag(dispatch, FLAGS.SHOW_OPENSHIFT_START_GUIDE, false),
 });
 
-const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNamespaceModal extends PromiseComponent {
+const CreateNamespaceModal = connect(mapStateToProps, mapDispatchToProps)(class CreateNamespaceModal extends PromiseComponent {
   constructor(props) {
     super(props);
     this.state.np = allow;
@@ -69,7 +77,7 @@ const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNames
 
   _submit(event) {
     event.preventDefault();
-    const { createProject, close } = this.props;
+    const { activePerspective, createProject, close } = this.props;
 
     let promise = createProject ? this.createProject() : this.createNamespace();
     if (this.state.np === deny) {
@@ -84,9 +92,9 @@ const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNames
       close();
       if (createProject) {
         // Redirect to the overview instead of the project details page.
-        history.push(`/overview/ns/${obj.metadata.name}`);
+        history.push(pathWithPerspective(activePerspective, `/overview/ns/${obj.metadata.name}`));
       } else {
-        history.push(resourceObjPath(obj, referenceFor(obj)));
+        history.push(pathWithPerspective(activePerspective, resourceObjPath(obj, referenceFor(obj))));
       }
     });
   }

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { CSSTransition } from 'react-transition-group';
 import { Helmet } from 'react-helmet';
-import { Link } from 'react-router-dom';
 import { Toolbar, EmptyState } from 'patternfly-react';
 
 import { coFetchJSON } from '../../co-fetch';
@@ -49,6 +48,7 @@ import { overviewMenuActions, OverviewNamespaceDashboard } from './namespace-ove
 import { ProjectOverview } from './project-overview';
 import { ResourceOverviewPage } from './resource-overview-page';
 import { PodStatus } from '../pod';
+import PerspectiveLink from '../../extend/devconsole/shared/components/PerspectiveLink';
 
 enum View {
   Resources = 'resources',
@@ -298,9 +298,9 @@ const isReservedNamespace = (ns: string) => ns === 'default' || ns === 'openshif
 
 const OverviewItemReadiness: React.SFC<OverviewItemReadinessProps> = ({desired = 0, ready = 0, resource}) => {
   const href = `${resourceObjPath(resource, resource.kind)}/pods`;
-  return <Link to={href}>
+  return <PerspectiveLink to={href}>
     {ready} of {desired} pods
-  </Link>;
+  </PerspectiveLink>;
 };
 
 const overviewEmptyStateToProps = ({UI}) => ({
@@ -319,17 +319,17 @@ const OverviewEmptyState = connect(overviewEmptyStateToProps)(({activeNamespace,
         Add content to your project from the catalog of web frameworks, databases, and other components. You may also deploy an existing image or create resources using YAML definitions.
       </EmptyState.Info>
       <EmptyState.Action>
-        <Link to="/catalog" className="btn btn-primary">
+        <PerspectiveLink to="/catalog" className="btn btn-primary">
           Browse Catalog
-        </Link>
+        </PerspectiveLink>
       </EmptyState.Action>
       <EmptyState.Action secondary>
-        <Link className="btn btn-default" to={`/deploy-image?preselected-ns=${activeNamespace}`}>
+        <PerspectiveLink className="btn btn-default" to={`/deploy-image?preselected-ns=${activeNamespace}`}>
           Deploy Image
-        </Link>
-        <Link className="btn btn-default" to={formatNamespacedRouteForResource('import', activeNamespace)}>
+        </PerspectiveLink>
+        <PerspectiveLink className="btn btn-default" to={formatNamespacedRouteForResource('import', activeNamespace)}>
           Import YAML
-        </Link>
+        </PerspectiveLink>
       </EmptyState.Action>
     </EmptyState>;
   }

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import { Link, withRouter, RouteComponentProps, match } from 'react-router-dom';
+import { withRouter, RouteComponentProps, match } from 'react-router-dom';
 
 import { k8sList, K8sResourceKind, planExternalName, serviceCatalogStatus, referenceForModel } from '../module/k8s';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
@@ -23,9 +23,11 @@ import { Conditions } from './conditions';
 import { ServiceCatalogParameters, ServiceCatalogParametersSecrets } from './service-catalog-parameters';
 import { ServiceBindingsPage } from './service-binding';
 import { ServiceBindingModel, ServiceInstanceModel, ClusterServiceClassModel } from '../models';
+import PerspectiveLink from '../extend/devconsole/shared/components/PerspectiveLink';
+import { pathWithPerspectiveFromStore } from './utils/perspective';
 
 const goToCreateBindingPage = (serviceInstance: K8sResourceKind) => {
-  history.push(`/k8s/ns/${serviceInstance.metadata.namespace}/serviceinstances/${serviceInstance.metadata.name}/create-binding`);
+  history.push(pathWithPerspectiveFromStore(`/k8s/ns/${serviceInstance.metadata.namespace}/serviceinstances/${serviceInstance.metadata.name}/create-binding`));
 };
 
 const createBinding = (kindObj, serviceInstance) => {
@@ -85,7 +87,7 @@ class ServiceInstanceMessage_ extends React.Component<ServiceInstanceMessageProp
         <i className="pficon pficon-warning-triangle-o" aria-hidden="true" />
         This service instance is marked for deletion, but still has bindings.
         You must delete the bindings before the instance will be deleted.&nbsp;&nbsp;
-        <Link to={`${basePath}/servicebindings`}>View Service Bindings</Link>
+        <PerspectiveLink to={`${basePath}/servicebindings`}>View Service Bindings</PerspectiveLink>
       </p>;
     }
 

--- a/frontend/public/components/utils/link.jsx
+++ b/frontend/public/components/utils/link.jsx
@@ -55,7 +55,7 @@ export const getNSPrefix = path => {
 };
 
 export const getNamespace = path => {
-  path = stripBasePath(path);
+  path = stripPerspectivePath(stripBasePath(path));
   const split = path.split('/').filter(x => x);
 
   if (split[1] === 'all-namespaces') {

--- a/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
+++ b/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
@@ -36,7 +36,7 @@ export const PageNav = (props: DevConsoleNavigationProps) => {
           isActive={isActive('/topology')}
         />
         <ResourceNSLink resource="buildconfigs" name={BuildModel.labelPlural} isActive={isActive('/buildconfigs')} />
-        <HrefLink href="/pipelines" name="Piplines" activePath="/pipelines" isActive={isActive('/pipelines')} />
+        <HrefLink href="/pipelines" name="Pipelines" activePath="/pipelines" isActive={isActive('/pipelines')} />
         <DevNavSection title="Advanced">
           <ResourceClusterLink resource="projects" name="Projects" required={FLAGS.OPENSHIFT} />
           <HrefLink href="/overview" name="Status" activePath="/overview" required={FLAGS.OPENSHIFT} />


### PR DESCRIPTION
Fixed links to stay in the same perspective for 
- Empty State of Projects overview.
- Create Application
- Create new project or namespace.
- Create new service instance.
- Fix nav typo for Pipelines.