### PR TITLE
bugs fixes for nav and routes

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -196,7 +196,7 @@ class App extends React.PureComponent {
       this.props.flags.SHOW_DEV_CONSOLE &&
       this.props.activePerspective === 'dev'
     ) {
-      return <DevConsoleNavigation isNavOpen={true} />;
+      return <DevConsoleNavigation isNavOpen={this.state.isNavOpen} />;
     }
     return (
       <Navigation

--- a/frontend/public/extend/devconsole/routes.tsx
+++ b/frontend/public/extend/devconsole/routes.tsx
@@ -30,6 +30,7 @@ const routes: RouteProps[] = [
   },
   {
     path: '/dev',
+    exact: true,
     // eslint-disable-next-line react/display-name
     render: () => <Redirect to="/dev/topology" />,
   },


### PR DESCRIPTION
Found a couple of minor bugs:
 - dev console navigation wasn't collapsing for mobile. The value of `isNavOpen` was set to `true` instead of using the state value `this.state.isNavOpen` which gets updated on browser resize.
 - Fixed the default route to be an exact match. Otherwise navigating to `/dev/foobar` would also redirect to the default route. Although appropriate, the admin console behavior is to display an error 404 page.