### PR TITLE
Create empty state component and add in topology view and +add view

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -74,13 +74,13 @@ _.each(namespacedPrefixes, p => {
   namespacedRoutes.push(`${p}/all-namespaces`);
 });
 
-export const appendActiveNamespace = pathname => {
+const appendActiveNamespace = pathname => {
   const basePath = pathname.replace(/\/$/, '');
   const activeNamespace = getActiveNamespace();
   return activeNamespace === ALL_NAMESPACES_KEY ? `${basePath}/all-namespaces` : `${basePath}/ns/${activeNamespace}`;
 };
 
-const NamespaceRedirect = ({location: {pathname}}) => {
+export const NamespaceRedirect = ({location: {pathname}}) => {
   const to = appendActiveNamespace(pathname) + location.search;
   return <Redirect to={to} />;
 };

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -74,7 +74,7 @@ _.each(namespacedPrefixes, p => {
   namespacedRoutes.push(`${p}/all-namespaces`);
 });
 
-const appendActiveNamespace = pathname => {
+export const appendActiveNamespace = pathname => {
   const basePath = pathname.replace(/\/$/, '');
   const activeNamespace = getActiveNamespace();
   return activeNamespace === ALL_NAMESPACES_KEY ? `${basePath}/all-namespaces` : `${basePath}/ns/${activeNamespace}`;

--- a/frontend/public/components/utils/link.jsx
+++ b/frontend/public/components/utils/link.jsx
@@ -34,6 +34,7 @@ export const defaultNamespacedPrefixes = [
   '/operators',
   '/operatormanagement',
   '/operatorhub',
+  '/add',
 ];
 
 

--- a/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
+++ b/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
@@ -9,7 +9,6 @@ import { BuildModel } from '../../../models';
 interface DevConsoleNavigationProps {
   isNavOpen: boolean;
   location: string;
-  activeNamespace: string;
   onNavSelect: () => void;
   onToggle: () => void;
 }
@@ -24,24 +23,38 @@ export const PageNav = (props: DevConsoleNavigationProps) => {
   return (
     <Nav aria-label="Nav" onSelect={props.onNavSelect} onToggle={props.onToggle}>
       <NavList>
-        <HrefLink
-          href="/add"
-          name="+Add"
-          activePath="/dev/add"
-          isActive={isActive('/add')}
-        />
+        <HrefLink href="/add" name="+Add" activePath="/dev/add" isActive={isActive('/add')} />
         <HrefLink
           href="/topology"
           name="Topology"
           activePath="/dev/topology"
           isActive={isActive('/topology')}
         />
-        <ResourceNSLink resource="buildconfigs" name={BuildModel.labelPlural} isActive={isActive('/buildconfigs')} />
-        <HrefLink href="/pipelines" name="Pipelines" activePath="/pipelines" isActive={isActive('/pipelines')} />
+        <ResourceNSLink
+          resource="buildconfigs"
+          name={BuildModel.labelPlural}
+          isActive={isActive('/buildconfigs')}
+        />
+        <HrefLink
+          href="/pipelines"
+          name="Pipelines"
+          activePath="/pipelines"
+          isActive={isActive('/pipelines')}
+        />
         <DevNavSection title="Advanced">
           <ResourceClusterLink resource="projects" name="Projects" required={FLAGS.OPENSHIFT} />
-          <HrefLink href="/overview" name="Status" activePath="/overview" required={FLAGS.OPENSHIFT} />
-          <HrefLink href="/status" name="Status" activePath="/status" disallowed={FLAGS.OPENSHIFT} />
+          <HrefLink
+            href="/overview"
+            name="Status"
+            activePath="/overview"
+            required={FLAGS.OPENSHIFT}
+          />
+          <HrefLink
+            href="/status"
+            name="Status"
+            activePath="/status"
+            disallowed={FLAGS.OPENSHIFT}
+          />
           <ResourceNSLink resource="events" name="Events" />
           <HrefLink href="/search" name="Search" activePath="/search" />
         </DevNavSection>
@@ -59,7 +72,6 @@ export const DevConsoleNavigation: React.FunctionComponent<DevConsoleNavigationP
 const mapStateToProps = (state) => {
   return {
     location: state.UI.get('location'),
-    activeNamespace: state.UI.get('activeNamespace'),
   };
 };
 

--- a/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
+++ b/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
@@ -9,6 +9,7 @@ import { BuildModel } from '../../../models';
 interface DevConsoleNavigationProps {
   isNavOpen: boolean;
   location: string;
+  activeNamespace: string;
   onNavSelect: () => void;
   onToggle: () => void;
 }
@@ -58,6 +59,7 @@ export const DevConsoleNavigation: React.FunctionComponent<DevConsoleNavigationP
 const mapStateToProps = (state) => {
   return {
     location: state.UI.get('location'),
+    activeNamespace: state.UI.get('activeNamespace'),
   };
 };
 

--- a/frontend/public/extend/devconsole/components/__tests__/DevConsoleNav.spec.tsx
+++ b/frontend/public/extend/devconsole/components/__tests__/DevConsoleNav.spec.tsx
@@ -8,7 +8,6 @@ function shallowSetup() {
   const props = {
     location: '/devops',
     isNavOpen: true,
-    activeNamespace: '',
     onNavSelect: () => {},
     onToggle: () => {},
   };

--- a/frontend/public/extend/devconsole/components/__tests__/DevConsoleNav.spec.tsx
+++ b/frontend/public/extend/devconsole/components/__tests__/DevConsoleNav.spec.tsx
@@ -8,6 +8,7 @@ function shallowSetup() {
   const props = {
     location: '/devops',
     isNavOpen: true,
+    activeNamespace: '',
     onNavSelect: () => {},
     onToggle: () => {},
   };

--- a/frontend/public/extend/devconsole/pages/Add.tsx
+++ b/frontend/public/extend/devconsole/pages/Add.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import ODCEmptyState from '../shared/components/EmptyState/EmptyState';
+
+const AddPage: React.FunctionComponent = () => <ODCEmptyState />;
+
+export default AddPage;

--- a/frontend/public/extend/devconsole/pages/Topology.tsx
+++ b/frontend/public/extend/devconsole/pages/Topology.tsx
@@ -1,14 +1,56 @@
+/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
+import * as _ from 'lodash-es';
+import ODCEmptyState from '../shared/components/EmptyState/EmptyState';
+import { Firehose, StatusBox } from '../../../components/utils';
+import { K8sResourceKind } from '../../../module/k8s/index';
 
-const TopologyPage: React.SFC = () => (
-  <div className="co-well">
-    <h4>Developer console Getting Started</h4>
-    <p>
-      Developer console is an internal feature and enabled only in development. See our documention
-      for instructions on how to enable the devconsole.
-    </p>
-    <p>Developer console is an alpha feature.</p>
-  </div>
-);
+export interface TopologyPageContentProps {
+  deploymentConfigs?: FirehoseList;
+  loaded?: boolean;
+  loadError?: string;
+}
+
+export interface TopologyPageProps {
+  match: any;
+}
+
+export const TopologyPageContent: React.FunctionComponent<TopologyPageContentProps> = (
+  props: TopologyPageContentProps,
+) => {
+  return (
+    <StatusBox
+      data={props.deploymentConfigs.data}
+      label="Topology"
+      loaded={props.loaded}
+      loadError={props.loadError}
+      EmptyMsg={ODCEmptyState}
+    >
+      <h1>This is Topology View</h1>
+    </StatusBox>
+  );
+};
+
+const TopologyPage: React.FunctionComponent<TopologyPageProps> = (props: TopologyPageProps) => {
+  const namespace = _.get(props.match, 'param-ns');
+  const resources = [
+    {
+      isList: true,
+      kind: 'DeploymentConfig',
+      namespace,
+      prop: 'deploymentConfigs',
+    },
+  ];
+  return (
+    <Firehose resources={resources} forceUpdate>
+      <TopologyPageContent />
+    </Firehose>
+  );
+};
 
 export default TopologyPage;
+
+type FirehoseList = {
+  data?: K8sResourceKind[];
+  [key: string]: any;
+};

--- a/frontend/public/extend/devconsole/pages/Topology.tsx
+++ b/frontend/public/extend/devconsole/pages/Topology.tsx
@@ -1,9 +1,14 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
-import * as _ from 'lodash-es';
+import { match as RMatch } from 'react-router';
 import ODCEmptyState from '../shared/components/EmptyState/EmptyState';
 import { Firehose, StatusBox } from '../../../components/utils';
 import { K8sResourceKind } from '../../../module/k8s/index';
+
+type FirehoseList = {
+  data?: K8sResourceKind[];
+  [key: string]: any;
+};
 
 export interface TopologyPageContentProps {
   deploymentConfigs?: FirehoseList;
@@ -12,7 +17,9 @@ export interface TopologyPageContentProps {
 }
 
 export interface TopologyPageProps {
-  match: any;
+  match: RMatch<{
+    ns?: string;
+  }>;
 }
 
 export const TopologyPageContent: React.FunctionComponent<TopologyPageContentProps> = (
@@ -32,7 +39,7 @@ export const TopologyPageContent: React.FunctionComponent<TopologyPageContentPro
 };
 
 const TopologyPage: React.FunctionComponent<TopologyPageProps> = (props: TopologyPageProps) => {
-  const namespace = _.get(props.match, 'param-ns');
+  const namespace = props.match.params.ns;
   const resources = [
     {
       isList: true,
@@ -49,8 +56,3 @@ const TopologyPage: React.FunctionComponent<TopologyPageProps> = (props: Topolog
 };
 
 export default TopologyPage;
-
-type FirehoseList = {
-  data?: K8sResourceKind[];
-  [key: string]: any;
-};

--- a/frontend/public/extend/devconsole/routes.tsx
+++ b/frontend/public/extend/devconsole/routes.tsx
@@ -2,19 +2,42 @@
 import * as React from 'react';
 import { RouteProps, Redirect } from 'react-router';
 import { AsyncComponent } from '../../components/utils';
+import { appendActiveNamespace } from '../../components/app';
+
+interface RedirectToNamespaceProps {
+  location: {
+    pathname?: string;
+    search?: string;
+  };
+}
+
+const RedirectToNamespace: React.FunctionComponent<RedirectToNamespaceProps> = (
+  props: RedirectToNamespaceProps,
+) => {
+  const to = appendActiveNamespace(props.location.pathname) + props.location.search;
+  return <Redirect to={to} />;
+};
 
 const routes: RouteProps[] = [
+  ...(() =>
+    ['/dev/add/all-namespaces', '/dev/add/ns/:ns'].map((path) => ({
+      path,
+      exact: true,
+      // eslint-disable-next-line react/display-name
+      render: (props) => (
+        <AsyncComponent
+          {...props}
+          loader={async() =>
+            (await import('./pages/Add' /* webpackChunkName: "devconsole-add" */)).default
+          }
+        />
+      ),
+    })))(),
   {
     path: '/dev/add',
+    exact: true,
     // eslint-disable-next-line react/display-name
-    render: (props) => (
-      <AsyncComponent
-        {...props}
-        loader={async() =>
-          (await import('./pages/Import' /* webpackChunkName: "devconsole-import" */)).default
-        }
-      />
-    ),
+    render: (props) => <RedirectToNamespace location={props.location} />,
   },
   {
     path: '/dev/topology',

--- a/frontend/public/extend/devconsole/routes.tsx
+++ b/frontend/public/extend/devconsole/routes.tsx
@@ -2,21 +2,7 @@
 import * as React from 'react';
 import { RouteProps, Redirect } from 'react-router';
 import { AsyncComponent } from '../../components/utils';
-import { appendActiveNamespace } from '../../components/app';
-
-interface RedirectToNamespaceProps {
-  location: {
-    pathname?: string;
-    search?: string;
-  };
-}
-
-const RedirectToNamespace: React.FunctionComponent<RedirectToNamespaceProps> = (
-  props: RedirectToNamespaceProps,
-) => {
-  const to = appendActiveNamespace(props.location.pathname) + props.location.search;
-  return <Redirect to={to} />;
-};
+import { NamespaceRedirect } from '../../components/app';
 
 const routes: RouteProps[] = [
   ...(() =>
@@ -37,7 +23,7 @@ const routes: RouteProps[] = [
     path: '/dev/add',
     exact: true,
     // eslint-disable-next-line react/display-name
-    render: (props) => <RedirectToNamespace location={props.location} />,
+    render: (props) => <NamespaceRedirect {...props} />,
   },
   {
     path: '/dev/topology',

--- a/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.scss
+++ b/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.scss
@@ -1,4 +1,5 @@
 .odc-empty-state {
-  margin-left: 25%;
+  margin-left: auto;
+  margin-right: auto;
   margin-top: 10%;
 }

--- a/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.scss
+++ b/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.scss
@@ -1,0 +1,4 @@
+.odc-empty-state {
+  margin-left: 25%;
+  margin-top: 15%;
+}

--- a/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.scss
+++ b/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.scss
@@ -1,4 +1,4 @@
 .odc-empty-state {
   margin-left: 25%;
-  margin-top: 15%;
+  margin-top: 10%;
 }

--- a/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.tsx
+++ b/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,64 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import { Title, EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import { connect } from 'react-redux';
+import { getActiveNamespace, getActivePerspective } from '../../../../../ui/ui-selectors';
+import { PerspectiveLink } from '../PerspectiveLink';
+import { formatNamespacedRouteForResource } from '../../../../../ui/ui-actions';
+import './EmptyState.scss';
+
+interface StateProps {
+  activePerspective: string;
+  activeNamespace: string;
+}
+
+export type ODCEmptyStateProps = StateProps;
+
+const ODCEmptyState: React.FunctionComponent<ODCEmptyStateProps> = (props: ODCEmptyStateProps) => (
+  <EmptyState className="odc-empty-state">
+    <Title size="xl">Get started with your project.</Title>
+    <EmptyStateBody>
+      Add content to your project from the catalog of web frameworks, databases, and other
+      components. You may also deploy an existing image or create resources using YAML definitions.
+    </EmptyStateBody>
+    <div
+      style={{
+        display: 'flex',
+        flexFlow: 'row nowrap',
+        justifyContent: 'space-evenly',
+        margin: '32px',
+      }}
+    >
+      <PerspectiveLink
+        className="btn btn-primary"
+        activePerspective={props.activePerspective}
+        to="/catalog"
+      >
+        Browse Catalog
+      </PerspectiveLink>
+      <PerspectiveLink
+        className="btn btn-primary"
+        activePerspective={props.activePerspective}
+        to={`/deploy-image?preselected-ns=${props.activeNamespace}`}
+      >
+        Deploy Image
+      </PerspectiveLink>
+      <PerspectiveLink
+        className="btn btn-primary"
+        activePerspective={props.activePerspective}
+        to={formatNamespacedRouteForResource('import', props.activeNamespace)}
+      >
+        Import YAML
+      </PerspectiveLink>
+    </div>
+  </EmptyState>
+);
+
+const mapStateToProps = (state): StateProps => {
+  return {
+    activePerspective: getActivePerspective(state),
+    activeNamespace: getActiveNamespace(state),
+  };
+};
+
+export default connect<StateProps, {}, {}>(mapStateToProps, () => ({}))(ODCEmptyState);

--- a/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.tsx
+++ b/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.tsx
@@ -25,6 +25,12 @@ const ODCEmptyState: React.FunctionComponent<ODCEmptyStateProps> = (props: ODCEm
       components. You may also deploy an existing image or create resources using YAML definitions.
     </EmptyStateBody>
     <EmptyStateSecondaryActions>
+      <PerspectiveLink
+        className="pf-c-button pf-m-primary"
+        to={formatNamespacedRouteForResource('git-import', props.activeNamespace)}
+      >
+        Import from Git
+      </PerspectiveLink>
       <PerspectiveLink className="pf-c-button pf-m-primary" to="/catalog">
         Browse Catalog
       </PerspectiveLink>

--- a/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.tsx
+++ b/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.tsx
@@ -25,10 +25,7 @@ const ODCEmptyState: React.FunctionComponent<ODCEmptyStateProps> = (props: ODCEm
       components. You may also deploy an existing image or create resources using YAML definitions.
     </EmptyStateBody>
     <EmptyStateSecondaryActions>
-      <PerspectiveLink
-        className="pf-c-button pf-m-primary"
-        to={formatNamespacedRouteForResource('git-import', props.activeNamespace)}
-      >
+      <PerspectiveLink className="pf-c-button pf-m-primary" to="/git-import">
         Import from Git
       </PerspectiveLink>
       <PerspectiveLink className="pf-c-button pf-m-primary" to="/catalog">
@@ -59,4 +56,4 @@ const mapStateToProps = (state): StateProps => {
   };
 };
 
-export default connect<StateProps, {}, {}>(mapStateToProps, () => ({}))(ODCEmptyState);
+export default connect<StateProps>(mapStateToProps)(ODCEmptyState);

--- a/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.tsx
+++ b/frontend/public/extend/devconsole/shared/components/EmptyState/EmptyState.tsx
@@ -1,14 +1,17 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
-import { Title, EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import {
+  Title,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+} from '@patternfly/react-core';
 import { connect } from 'react-redux';
-import { getActiveNamespace, getActivePerspective } from '../../../../../ui/ui-selectors';
-import { PerspectiveLink } from '../PerspectiveLink';
+import PerspectiveLink from '../PerspectiveLink';
 import { formatNamespacedRouteForResource } from '../../../../../ui/ui-actions';
 import './EmptyState.scss';
 
 interface StateProps {
-  activePerspective: string;
   activeNamespace: string;
 }
 
@@ -21,43 +24,32 @@ const ODCEmptyState: React.FunctionComponent<ODCEmptyStateProps> = (props: ODCEm
       Add content to your project from the catalog of web frameworks, databases, and other
       components. You may also deploy an existing image or create resources using YAML definitions.
     </EmptyStateBody>
-    <div
-      style={{
-        display: 'flex',
-        flexFlow: 'row nowrap',
-        justifyContent: 'space-evenly',
-        margin: '32px',
-      }}
-    >
-      <PerspectiveLink
-        className="btn btn-primary"
-        activePerspective={props.activePerspective}
-        to="/catalog"
-      >
+    <EmptyStateSecondaryActions>
+      <PerspectiveLink className="pf-c-button pf-m-primary" to="/catalog">
         Browse Catalog
       </PerspectiveLink>
       <PerspectiveLink
-        className="btn btn-primary"
-        activePerspective={props.activePerspective}
+        className="pf-c-button pf-m-primary"
         to={`/deploy-image?preselected-ns=${props.activeNamespace}`}
       >
         Deploy Image
       </PerspectiveLink>
       <PerspectiveLink
-        className="btn btn-primary"
-        activePerspective={props.activePerspective}
+        className="pf-c-button pf-m-primary"
         to={formatNamespacedRouteForResource('import', props.activeNamespace)}
       >
         Import YAML
       </PerspectiveLink>
-    </div>
+      <PerspectiveLink className="pf-c-button pf-m-primary" to="/catalog?category=databases">
+        Add Database
+      </PerspectiveLink>
+    </EmptyStateSecondaryActions>
   </EmptyState>
 );
 
 const mapStateToProps = (state): StateProps => {
   return {
-    activePerspective: getActivePerspective(state),
-    activeNamespace: getActiveNamespace(state),
+    activeNamespace: state.UI.get('activeNamespace'),
   };
 };
 

--- a/frontend/public/extend/devconsole/shared/components/__tests__/EmptyState.spec.tsx
+++ b/frontend/public/extend/devconsole/shared/components/__tests__/EmptyState.spec.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { Map as ImmutableMap } from 'immutable';
+import { shallow } from 'enzyme';
+import ConnectedEmptyStateComponent from '../EmptyState/EmptyState';
+import { getStoreTypedComponent } from '../../../utils/test-utils';
+
+describe('EmptyState', () => {
+  const mockStore = configureMockStore();
+  const ConnectedComponent = getStoreTypedComponent(ConnectedEmptyStateComponent);
+
+  it('should pass activeNamespace from state as prop', () => {
+    const store = mockStore({
+      UI: ImmutableMap({
+        activeNamespace: 'project',
+      }),
+    });
+
+    const topologyWrapper = shallow(<ConnectedComponent store={store} />);
+
+    expect(topologyWrapper.props().resources).toEqual('project');
+  });
+
+  it('should pass resources from state as prop', () => {
+    const store = mockStore({
+      UI: ImmutableMap({
+        activePerspective: 'dev',
+      }),
+    });
+
+    const topologyWrapper = shallow(<ConnectedComponent store={store} />);
+
+    expect(topologyWrapper.props().resources).toEqual('dev');
+  });
+});

--- a/frontend/public/ui/ui-selectors.js
+++ b/frontend/public/ui/ui-selectors.js
@@ -1,2 +1,1 @@
-export const getActivePerspective = (state) => state.UI.get('activePerspective');
-export const getActiveNamespace = (state) => state.UI.get('activeNamespace');
+export const getActivePerspective = state => state.UI.get('activePerspective');

--- a/frontend/public/ui/ui-selectors.js
+++ b/frontend/public/ui/ui-selectors.js
@@ -1,1 +1,2 @@
 export const getActivePerspective = (state) => state.UI.get('activePerspective');
+export const getActiveNamespace = (state) => state.UI.get('activeNamespace');


### PR DESCRIPTION
Story: https://jira.coreos.com/browse/ODC-421
Story: https://jira.coreos.com/browse/ODC-434

In this PR I have implemented:
- `EmptyState` component
- Added `EmptyState` in `Topology` view
- Added checks for deciding when to display `EmptyState`  in `Topology` view
- Added test cases for `EmptyState`
- Added `EmptyState` in `+Add` view
- Added `Namespace Bar` in `+Add` view
- Added routes for `/dev/add/ns/:ns` and `/dev/add/all-namespaces`
- Redirect `/dev/add` to  `/dev/add/ns/:ns`

Topology View
![empty-state](https://user-images.githubusercontent.com/20724543/56306886-4f336100-6161-11e9-96b8-89ca13737c1a.gif)

Update:
![Screenshot from 2019-04-23 13-41-17](https://user-images.githubusercontent.com/20724543/56565264-9e4c1c80-65cd-11e9-8e53-9913f843deb6.png)

+Add View
![Screenshot from 2019-04-23 14-25-32](https://user-images.githubusercontent.com/20724543/56568503-c8eda380-65d4-11e9-9e8a-b326f87cf5d8.png)


Note
We can close this story once the reviews are done and we can create another story to take care of the new UX design as it is still WIP @christianvogt ^^