### PR TITLE
fix(import): remove not supported version of image stream from builde…

### DIFF
--- a/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
@@ -426,7 +426,9 @@ export class ImportFlowForm extends React.Component<Props, State> {
 
     builderImages.forEach((image) => {
       image.spec.tags.forEach((tag) => {
-        this.imageStreams[image.metadata.name + tag.name] = [image.metadata.name, tag.name];
+        if (!tag.annotations.tags.includes('hidden')) {
+          this.imageStreams[image.metadata.name+tag.name] = [image.metadata.name, tag.name];
+        }
       });
     });
 

--- a/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
@@ -420,17 +420,19 @@ export class ImportFlowForm extends React.Component<Props, State> {
       builderImageError,
     } = this.state;
 
-    const builderImages = _.filter(this.props.resources.imagestreams.data, (imagestream) => {
-      return isBuilder(imagestream);
-    });
-
-    builderImages.forEach((image) => {
-      image.spec.tags.forEach((tag) => {
-        if (!tag.annotations.tags.includes('hidden')) {
-          this.imageStreams[image.metadata.name+tag.name] = [image.metadata.name, tag.name];
-        }
+    if(this.props.resources.imagestreams.loaded) {
+      const builderImages = _.filter(this.props.resources.imagestreams.data, (imagestream) => {
+        return isBuilder(imagestream);
       });
-    });
+
+      builderImages.forEach((image) => {
+        image.spec.tags.forEach((tag) => {
+          if (!tag.annotations.tags.includes('hidden')) {
+            this.imageStreams[image.metadata.name+tag.name] = [image.metadata.name, tag.name];
+          }
+        });
+      });
+    }
 
     let gitTypeField, showGitValidationStatus, showDetectBuildToolStatus;
     if (gitType || gitTypeError) {

--- a/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
@@ -420,7 +420,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
       builderImageError,
     } = this.state;
 
-    if(this.props.resources.imagestreams.loaded) {
+    if (this.props.resources.imagestreams.loaded) {
       const builderImages = _.filter(this.props.resources.imagestreams.data, (imagestream) => {
         return isBuilder(imagestream);
       });

--- a/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
@@ -495,7 +495,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
             autoComplete="off"
             name="gitRepoUrl"
           />
-          <HelpBlock>{gitRepoUrlError ? gitRepoUrlError : 'Some helper text'}</HelpBlock>
+          <HelpBlock>{gitRepoUrlError ? gitRepoUrlError : ''}</HelpBlock>
         </FormGroup>
         {gitTypeField}
         <FormGroup
@@ -509,7 +509,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
             data-test-id="import-application-name"
           />
           <HelpBlock>
-            {namespaceError ? namespaceError : 'Some help text with explanation'}
+            {namespaceError ? namespaceError : ''}
           </HelpBlock>
         </FormGroup>
         <AppNameSelector
@@ -556,7 +556,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
             data-test-id="import-builder-image"
           />
           <HelpBlock>
-            {builderImageError ? builderImageError : 'Some help text with explanation'}
+            {builderImageError ? builderImageError : ''}
           </HelpBlock>
         </FormGroup>
         <div className="co-m-btn-bar">


### PR DESCRIPTION
…r image dropdown

Don't show those imagestreams which have ```tag=hidden``` under the annotations of the imagestreams.