### PR TITLE
prevent layout position lose on model updates

### DIFF
--- a/frontend/public/extend/devconsole/components/topology/D3ForceDirectedRenderer.tsx
+++ b/frontend/public/extend/devconsole/components/topology/D3ForceDirectedRenderer.tsx
@@ -271,7 +271,7 @@ export default class D3ForceDirectedRenderer extends React.Component<
               {edges.map((edgeId) => {
                 const data = topology[edgeId];
                 const viewEdge = edgesById[edgeId];
-                const Component = edgeProvider(data);
+                const Component = edgeProvider(viewEdge.type);
                 return <Component {...viewEdge} key={edgeId} data={data} />;
               })}
             </g>
@@ -279,7 +279,7 @@ export default class D3ForceDirectedRenderer extends React.Component<
               {nodes.map((nodeId) => {
                 const data = topology[nodeId];
                 const viewNode = nodesById[nodeId];
-                const Component = nodeProvider(data);
+                const Component = nodeProvider(viewNode.type);
                 return (
                   <ViewWrapper
                     component={Component}

--- a/frontend/public/extend/devconsole/components/topology/Graph.tsx
+++ b/frontend/public/extend/devconsole/components/topology/Graph.tsx
@@ -8,7 +8,6 @@ import {
   EdgeProvider,
   NodeProvider,
   GraphModel,
-  ViewGraphData,
   TopologyDataMap,
 } from './topology-types';
 import './Graph.scss';
@@ -28,11 +27,11 @@ export interface GraphProps {
   topology: TopologyDataMap;
   children?(GraphApi): React.ReactNode;
   selected?: string;
-  onSelect?(Node): void;
+  onSelect?(string): void;
 }
 
 export default class Graph extends React.Component<GraphProps, State> {
-  state = {
+  state: State = {
     dimensions: null,
     graphApi: null,
   };
@@ -72,8 +71,7 @@ export default class Graph extends React.Component<GraphProps, State> {
             nodeSize={125}
             height={dimensions.height}
             width={dimensions.width}
-            // TODO transform instead of blind cast
-            graph={graph as ViewGraphData}
+            graph={graph}
             topology={topology}
             nodeProvider={nodeProvider}
             edgeProvider={edgeProvider}

--- a/frontend/public/extend/devconsole/components/topology/Topology.tsx
+++ b/frontend/public/extend/devconsole/components/topology/Topology.tsx
@@ -5,7 +5,7 @@ import { ExpandIcon, SearchPlusIcon, SearchMinusIcon } from '@patternfly/react-i
 import { nodeProvider, edgeProvider } from './shape-providers';
 import Graph from './Graph';
 import GraphToolbar from './GraphToolbar';
-import { GraphApi, Node, TopologyDataModel } from './topology-types';
+import { GraphApi, TopologyDataModel } from './topology-types';
 
 type State = {
   selected?: string;
@@ -20,9 +20,9 @@ export default class Topology extends React.Component<TopologyProps, State> {
     selected: null,
   };
 
-  onSelect = (node: Node) => {
+  onSelect = (nodeId: string) => {
     this.setState(({ selected }) => {
-      return { selected: !node || selected === node.id ? null : node.id };
+      return { selected: !nodeId || selected === nodeId ? null : nodeId };
     });
   };
 

--- a/frontend/public/extend/devconsole/components/topology/shape-providers.ts
+++ b/frontend/public/extend/devconsole/components/topology/shape-providers.ts
@@ -4,7 +4,7 @@ import DefaultNode from './shapes/DefaultNode';
 import WorkloadNode from './shapes/WorkloadNode';
 import { NodeProvider, EdgeProvider } from './topology-types';
 
-export const nodeProvider: NodeProvider = ({ type }) => {
+export const nodeProvider: NodeProvider = (type) => {
   switch (type) {
     case 'workload':
       return WorkloadNode;
@@ -13,7 +13,7 @@ export const nodeProvider: NodeProvider = ({ type }) => {
   }
 };
 
-export const edgeProvider: EdgeProvider = ({ type }) => {
+export const edgeProvider: EdgeProvider = (type) => {
   switch (type) {
     default:
       return DefaultEdge;

--- a/frontend/public/extend/devconsole/components/topology/topology-types.ts
+++ b/frontend/public/extend/devconsole/components/topology/topology-types.ts
@@ -124,9 +124,9 @@ export type EdgeProps<D = {}> = ViewEdge & {
 };
 
 export interface NodeProvider {
-  (TopologyDataObject): ComponentType<NodeProps>;
+  (string): ComponentType<NodeProps>;
 }
 
 export interface EdgeProvider {
-  (TopologyDataObject): ComponentType<EdgeProps>;
+  (string): ComponentType<EdgeProps>;
 }

--- a/frontend/public/extend/devconsole/components/topology/topology-types.ts
+++ b/frontend/public/extend/devconsole/components/topology/topology-types.ts
@@ -28,7 +28,7 @@ export interface TopologyDataResources {
 }
 
 export interface Node {
-  id?: string;
+  id: string;
   type?: string;
   name?: string;
 }
@@ -60,6 +60,7 @@ export interface TopologyDataModel {
   graph: GraphModel;
   topology: TopologyDataMap;
 }
+
 export interface Pod {
   id: string;
   name: string;
@@ -96,24 +97,22 @@ export interface Selectable {
   onSelect?(): void;
 }
 
-export type ViewNode = Node & {
-  x?: number;
-  y?: number;
-  size?: number;
+export type ViewNode = {
+  id: string;
+  type?: string;
+  x: number;
+  y: number;
+  size: number;
 };
 
-export type ViewEdge = Edge & {
+export type ViewEdge = {
+  id: string;
+  type?: string;
   source: ViewNode;
   target: ViewNode;
 };
 
 export type ViewGroup = Group;
-
-export interface ViewGraphData {
-  nodes: ViewNode[];
-  edges: ViewEdge[];
-  groups: ViewGroup[];
-}
 
 export type NodeProps<D = {}> = ViewNode &
   Selectable & {
@@ -125,9 +124,9 @@ export type EdgeProps<D = {}> = ViewEdge & {
 };
 
 export interface NodeProvider {
-  (ViewNode, any): ComponentType<NodeProps>;
+  (TopologyDataObject): ComponentType<NodeProps>;
 }
 
 export interface EdgeProvider {
-  (ViewNode, any): ComponentType<EdgeProps>;
+  (TopologyDataObject): ComponentType<EdgeProps>;
 }

--- a/frontend/public/extend/devconsole/components/topology/topology-utils.ts
+++ b/frontend/public/extend/devconsole/components/topology/topology-utils.ts
@@ -265,21 +265,7 @@ export class TransformTopologyData {
       });
     }
   }
-  /**
-   * Generate UUIDv4
-   *
-   */
-  generateUUID() {
-    let d = new Date().getTime();
-    if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
-      d += performance.now(); //use high-precision timer if available
-    }
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      const r = ((d + Math.random() * 16) % 16) | 0;
-      d = Math.floor(d / 16);
-      return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
-    });
-  }
+  
   /**
    * sort the deployement version
    */

--- a/frontend/public/extend/devconsole/components/topology/topology-utils.ts
+++ b/frontend/public/extend/devconsole/components/topology/topology-utils.ts
@@ -75,7 +75,7 @@ export class TransformTopologyData {
       // populate the graph Data
       this.createGraphData(deploymentConfig);
       // add the lookup object
-      const deploymentsLabels = _.get(deploymentConfig, 'metadata.labels');
+      const deploymentsLabels = _.get(deploymentConfig, 'metadata.labels') || {};
       this._topologyData.topology[dcUID] = {
         id: dcUID,
         name:
@@ -208,7 +208,7 @@ export class TransformTopologyData {
     const currentNode = {
       id: metadata.uid,
       type: 'workload',
-      name: metadata.labels['app.openshift.io/instance'] || metadata.name,
+      name: (metadata.labels && metadata.labels['app.openshift.io/instance']) || metadata.name,
     };
 
     if (!_.some(this._topologyData.graph.nodes, { id: currentNode.id })) {


### PR DESCRIPTION
* changed `onSelect(Node)` to `onSelect(string)` where the param is the node ID
* fixed some `undefined` errors in `topology-utils`
* Implemented `getDerivedStateFromProps` in `D3ForceDirectedRenderer` in order to transform the `GraphModel` into an internal state representing the nodes and edges as view models specific to the layout. This allows for caching the view coordinates in a separate data structure which is re-created only if the nodes or edges change.