### PR TITLE
surround topology nodes within a group in a labelled outline

### DIFF
--- a/frontend/public/extend/devconsole/components/source-to-image/SourceToImage.tsx
+++ b/frontend/public/extend/devconsole/components/source-to-image/SourceToImage.tsx
@@ -37,7 +37,7 @@ const mapBuildSourceStateToProps = (state) => {
 class BuildSource extends React.Component<
   BuildSourceStateProps & BuildSourceProps,
   BuildSourceState
-> {
+  > {
   constructor(props) {
     super(props);
 
@@ -104,9 +104,7 @@ class BuildSource extends React.Component<
   };
 
   fillSample: React.ReactEventHandler<HTMLButtonElement> = (event) => {
-    const {
-      obj: { data: imageStream },
-    } = this.props;
+    const { obj: { data: imageStream } } = this.props;
     const { name: currentName, selectedTag } = this.state;
     const tag = _.find(imageStream.spec.tags, { name: selectedTag });
     const repository = getSampleRepo(tag);
@@ -122,9 +120,7 @@ class BuildSource extends React.Component<
       return;
     }
 
-    const {
-      obj: { data: imageStream },
-    } = this.props;
+    const { obj: { data: imageStream } } = this.props;
     const imageStreamTagName = `${imageStream.metadata.name}:${selectedTag}`;
     this.setState({ inProgress: true });
     k8sGet(ImageStreamTagModel, imageStreamTagName, imageStream.metadata.namespace).then(
@@ -144,10 +140,7 @@ class BuildSource extends React.Component<
 
   save = (event: React.FormEvent<EventTarget>) => {
     event.preventDefault();
-    const {
-      activePerspective,
-      obj: { data: imageStream },
-    } = this.props;
+    const { activePerspective, obj: { data: imageStream } } = this.props;
     const {
       name,
       namespace,
@@ -349,7 +342,9 @@ class BuildSource extends React.Component<
   }
 }
 
-export default connect<BuildSourceStateProps, {}, BuildSourceProps>(mapBuildSourceStateToProps)(BuildSource);
+export default connect<BuildSourceStateProps, {}, BuildSourceProps>(mapBuildSourceStateToProps)(
+  BuildSource,
+);
 
 export type BuildSourceProps = {
   obj?: any;

--- a/frontend/public/extend/devconsole/components/topology/D3ForceDirectedRenderer.tsx
+++ b/frontend/public/extend/devconsole/components/topology/D3ForceDirectedRenderer.tsx
@@ -282,16 +282,16 @@ export default class D3ForceDirectedRenderer extends React.Component<
     if (!d3.event.active) {
       this.simulation.alphaTarget(0.1).restart();
     }
-    d.nodes.forEach((d) => {
-      d.fx = d.x;
-      d.fy = d.y;
+    d.nodes.forEach((gd) => {
+      gd.fx = gd.x;
+      gd.fy = gd.y;
     });
   };
 
   onGroupDragged = (d: ViewGroup) => {
-    d.nodes.forEach((d) => {
-      d.fx += d3.event.dx;
-      d.fy += d3.event.dy;
+    d.nodes.forEach((gd) => {
+      gd.fx += d3.event.dx;
+      gd.fy += d3.event.dy;
     });
   };
 
@@ -299,9 +299,9 @@ export default class D3ForceDirectedRenderer extends React.Component<
     if (!d3.event.active) {
       this.simulation.alphaTarget(0);
     }
-    d.nodes.forEach((d) => {
-      d.fx = null;
-      d.fy = null;
+    d.nodes.forEach((gd) => {
+      gd.fx = null;
+      gd.fy = null;
     });
   };
 

--- a/frontend/public/extend/devconsole/components/topology/D3ForceDirectedRenderer.tsx
+++ b/frontend/public/extend/devconsole/components/topology/D3ForceDirectedRenderer.tsx
@@ -232,7 +232,8 @@ export default class D3ForceDirectedRenderer extends React.Component<
         .drag<SVGGElement, ViewNode>()
         .on('start', (d) => this.onNodeDragStart(d))
         .on('drag', (d) => this.onNodeDragged(d))
-        .on('end', (d) => this.onNodeDragEnd(d)),
+        .on('end', (d) => this.onNodeDragEnd(d))
+        .filter(() => this.state.nodes.length > 1),
     );
   };
 
@@ -274,7 +275,8 @@ export default class D3ForceDirectedRenderer extends React.Component<
         .drag<SVGGElement, ViewGroup>()
         .on('start', (d) => this.onGroupDragStart(d))
         .on('drag', (d) => this.onGroupDragged(d))
-        .on('end', (d) => this.onGroupDragEnd(d)),
+        .on('end', (d) => this.onGroupDragEnd(d))
+        .filter(() => this.state.groups.length > 1),
     );
   };
 

--- a/frontend/public/extend/devconsole/components/topology/Graph.tsx
+++ b/frontend/public/extend/devconsole/components/topology/Graph.tsx
@@ -9,6 +9,7 @@ import {
   NodeProvider,
   GraphModel,
   TopologyDataMap,
+  GroupProvider,
 } from './topology-types';
 import './Graph.scss';
 
@@ -23,6 +24,7 @@ interface State {
 export interface GraphProps {
   nodeProvider: NodeProvider;
   edgeProvider: EdgeProvider;
+  groupProvider: GroupProvider;
   graph: GraphModel;
   topology: TopologyDataMap;
   children?(GraphApi): React.ReactNode;
@@ -59,6 +61,7 @@ export default class Graph extends React.Component<GraphProps, State> {
       graph,
       nodeProvider,
       edgeProvider,
+      groupProvider,
       onSelect,
       selected,
       topology,
@@ -75,6 +78,7 @@ export default class Graph extends React.Component<GraphProps, State> {
             topology={topology}
             nodeProvider={nodeProvider}
             edgeProvider={edgeProvider}
+            groupProvider={groupProvider}
             ref={this.captureApiRef}
             onSelect={onSelect}
             selected={selected}

--- a/frontend/public/extend/devconsole/components/topology/Topology.tsx
+++ b/frontend/public/extend/devconsole/components/topology/Topology.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { Button } from 'patternfly-react';
 import { ExpandIcon, SearchPlusIcon, SearchMinusIcon } from '@patternfly/react-icons';
-import { nodeProvider, edgeProvider } from './shape-providers';
+import { nodeProvider, edgeProvider, groupProvider } from './shape-providers';
 import Graph from './Graph';
 import GraphToolbar from './GraphToolbar';
 import { GraphApi, TopologyDataModel } from './topology-types';
@@ -27,6 +27,10 @@ export default class Topology extends React.Component<TopologyProps, State> {
     });
   };
 
+  onSidebarClose = () => {
+    this.setState({ selected: null });
+  };
+
   renderToolbar = (graphApi: GraphApi) => (
     <GraphToolbar>
       <Button onClick={graphApi.zoomIn} title="Zoom In" aria-label="Zoom In">
@@ -42,23 +46,26 @@ export default class Topology extends React.Component<TopologyProps, State> {
   );
 
   render() {
+    const { data: { graph, topology } } = this.props;
+    const { selected } = this.state;
     return (
       <React.Fragment>
         <Graph
-          graph={this.props.data.graph}
-          topology={this.props.data.topology}
+          graph={graph}
+          topology={topology}
           nodeProvider={nodeProvider}
           edgeProvider={edgeProvider}
-          selected={this.state.selected}
+          groupProvider={groupProvider}
+          selected={selected}
           onSelect={this.onSelect}
         >
           {this.renderToolbar}
         </Graph>
         {this.state.selected ? (
           <TopologySideBar
-            item={this.props.data.topology[this.state.selected]}
-            selected={this.state.selected}
-            onClose={() => this.setState({selected: null})}
+            item={topology[selected]}
+            selected={selected}
+            onClose={this.onSidebarClose}
           />
         ) : null}
       </React.Fragment>

--- a/frontend/public/extend/devconsole/components/topology/Topology.tsx
+++ b/frontend/public/extend/devconsole/components/topology/Topology.tsx
@@ -21,6 +21,14 @@ export default class Topology extends React.Component<TopologyProps, State> {
     selected: null,
   };
 
+  static getDerivedStateFromProps(nextProps: TopologyProps, prevState: State): State {
+    const { selected } = prevState;
+    if (selected && !nextProps.data.topology[selected]) {
+      return { selected: null };
+    }
+    return prevState;
+  }
+
   onSelect = (nodeId: string) => {
     this.setState(({ selected }) => {
       return { selected: !nodeId || selected === nodeId ? null : nodeId };
@@ -61,12 +69,8 @@ export default class Topology extends React.Component<TopologyProps, State> {
         >
           {this.renderToolbar}
         </Graph>
-        {this.state.selected ? (
-          <TopologySideBar
-            item={topology[selected]}
-            selected={selected}
-            onClose={this.onSidebarClose}
-          />
+        {selected ? (
+          <TopologySideBar item={topology[selected]} show onClose={this.onSidebarClose} />
         ) : null}
       </React.Fragment>
     );

--- a/frontend/public/extend/devconsole/components/topology/TopologySideBar.tsx
+++ b/frontend/public/extend/devconsole/components/topology/TopologySideBar.tsx
@@ -12,6 +12,19 @@ export type TopologySideBarProps = {
   onClose: Function;
 };
 
+/**
+ * REMOVE: once we get labels in place
+ * This is a temporary check to avoid the `Warning: Each child in an array or iterator should have a unique "key" prop`.
+ * Its coming when buildConfig/route/service metadata is empty object,
+ * BuildOverviewList, RouteOverviewList, ServiceOverview list uses the metadata.uid as the value of `key` prop.
+ *
+ * Datacontroller get the buildConfigs based on apps.kubernetes.io/instance label which is not applied to apps created using browser catalog
+ */
+
+function metadataUIDCheck(items: any) {
+  return items.filter((item) => item.metadata && item.metadata.uid);
+}
+
 const TopologySideBar: React.FunctionComponent<TopologySideBarProps> = ({
   item,
   selected,
@@ -38,18 +51,5 @@ const TopologySideBar: React.FunctionComponent<TopologySideBarProps> = ({
     </ModelessOverlay>
   );
 };
-
-/**
- * REMOVE: once we get labels in place
- * This is a temporary check to avoid the `Warning: Each child in an array or iterator should have a unique "key" prop`.
- * Its coming when buildConfig/route/service metadata is empty object,
- * BuildOverviewList, RouteOverviewList, ServiceOverview list uses the metadata.uid as the value of `key` prop.
- *
- * Datacontroller get the buildConfigs based on apps.kubernetes.io/instance label which is not applied to apps created using browser catalog
- */
-
-function metadataUIDCheck(items: any) {
-  return items.filter((item) => item.metadata && item.metadata.uid);
-}
 
 export default TopologySideBar;

--- a/frontend/public/extend/devconsole/components/topology/TopologySideBar.tsx
+++ b/frontend/public/extend/devconsole/components/topology/TopologySideBar.tsx
@@ -8,7 +8,7 @@ import './TopologySideBar.scss';
 
 export type TopologySideBarProps = {
   item: TopologyDataObject;
-  selected: string;
+  show: boolean;
   onClose: Function;
 };
 
@@ -27,7 +27,7 @@ function metadataUIDCheck(items: any) {
 
 const TopologySideBar: React.FunctionComponent<TopologySideBarProps> = ({
   item,
-  selected,
+  show,
   onClose,
 }) => {
   const dc = item.resources.filter((o) => o.kind === 'DeploymentConfig' || o.kind === 'Deployment');
@@ -43,7 +43,7 @@ const TopologySideBar: React.FunctionComponent<TopologySideBarProps> = ({
   };
 
   return (
-    <ModelessOverlay className="odc-topology-sidebar__overlay" show={!!selected}>
+    <ModelessOverlay className="odc-topology-sidebar__overlay" show={show}>
       <div className="odc-topology-sidebar__dismiss clearfix">
         <CloseButton onClick={onClose} data-test-id="sidebar-close-button" />
       </div>

--- a/frontend/public/extend/devconsole/components/topology/__mocks__/TopologyResourcesMocks.ts
+++ b/frontend/public/extend/devconsole/components/topology/__mocks__/TopologyResourcesMocks.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars, no-undef */
 import { TopologyDataResources, Resource } from '../topology-types';
 
 export const sampleDeploymentConfigs: Resource = {
@@ -9,7 +10,7 @@ export const sampleDeploymentConfigs: Resource = {
         name: 'nodejs',
         namespace: 'testproject1',
         selfLink: '/apis/apps.openshift.io/v1/namespaces/testproject1/deploymentconfigs/nodejs',
-        uid: "02f680df-680f-11e9-b69e-5254003f9382",
+        uid: '02f680df-680f-11e9-b69e-5254003f9382',
         resourceVersion: '732186',
         generation: 2,
         creationTimestamp: '2019-04-22T11:58:33Z',

--- a/frontend/public/extend/devconsole/components/topology/__tests__/TopologyDataController.spec.tsx
+++ b/frontend/public/extend/devconsole/components/topology/__tests__/TopologyDataController.spec.tsx
@@ -7,7 +7,6 @@ import { renderTopology } from '../../../pages/Topology';
 import ODCEmptyState from '../../../shared/components/EmptyState/EmptyState';
 
 describe('TopologyDataController', () => {
-
   const props = {
     namespace: 'test',
     resources,
@@ -24,6 +23,6 @@ describe('TopologyDataController', () => {
   });
 
   it('should render the empty state component', () => {
-    expect(wrapper.find(<ODCEmptyState title="Topology"  />)).toBeTruthy();
+    expect(wrapper.find(<ODCEmptyState title="Topology" />)).toBeTruthy();
   });
 });

--- a/frontend/public/extend/devconsole/components/topology/shape-providers.ts
+++ b/frontend/public/extend/devconsole/components/topology/shape-providers.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-unused-vars, no-undef */
 import DefaultEdge from './shapes/DefaultEdge';
 import DefaultNode from './shapes/DefaultNode';
+import DefaultGroup from './shapes/DefaultGroup';
 import WorkloadNode from './shapes/WorkloadNode';
-import { NodeProvider, EdgeProvider } from './topology-types';
+import { NodeProvider, EdgeProvider, GroupProvider } from './topology-types';
 
 export const nodeProvider: NodeProvider = (type) => {
   switch (type) {
@@ -17,5 +18,12 @@ export const edgeProvider: EdgeProvider = (type) => {
   switch (type) {
     default:
       return DefaultEdge;
+  }
+};
+
+export const groupProvider: GroupProvider = (type) => {
+  switch (type) {
+    default:
+      return DefaultGroup;
   }
 };

--- a/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.scss
+++ b/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.scss
@@ -7,7 +7,7 @@
   &__label {
     pointer-events: none;
     fill: var(--pf-global--Color--100);
-    font-size: var(--pf-global--icon--FontSize--md);
+    font-size: var(--pf-global--FontSize--md);
 
     &.is-selected {
       fill: var(--pf-global--active-color--300);

--- a/frontend/public/extend/devconsole/components/topology/shapes/DefaultGroup.scss
+++ b/frontend/public/extend/devconsole/components/topology/shapes/DefaultGroup.scss
@@ -1,0 +1,16 @@
+.odc-default-group {
+  fill: var(--pf-global--BackgroundColor--200);
+
+  &__label {
+    pointer-events: none;
+
+    & rect {
+      fill: var(--pf-global--Color--300);
+    }
+
+    & text {
+      fill: #fff;
+      font-size: var(--pf-global--FontSize--sm);
+    }
+  }
+}

--- a/frontend/public/extend/devconsole/components/topology/shapes/DefaultGroup.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/DefaultGroup.tsx
@@ -1,0 +1,98 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import * as d3 from 'd3';
+import { GroupProps, ViewNode } from '../topology-types';
+import SvgBoxedText from '../../../shared/components/svg/SvgBoxedText';
+import './DefaultGroup.scss';
+
+const valueline = d3
+  .line()
+  .x((d) => d[0])
+  .y((d) => d[1])
+  .curve(d3.curveBasisClosed);
+
+// Return the point whose Y is the largest value.
+function findLowestPoint(points: [number, number][]): [number, number] {
+  let lowestPoint = points[0];
+
+  points.forEach((p) => {
+    if (p[1] > lowestPoint[1]) {
+      lowestPoint = p;
+    }
+  });
+
+  return lowestPoint;
+}
+
+// Padding around group points in pixels.
+const GP = 50;
+
+// Returns an array of points representing 8 points around the center of the node.
+// We use these points to ensure that the surrounding group box does not intersect with the node.
+function getNodePoints(node: ViewNode): [number, number][] {
+  const radius = node.size / 2;
+  const x0 = node.x - radius;
+  const x1 = node.x + radius;
+  const y0 = node.y - radius;
+  const y1 = node.y + radius;
+  return [
+    ...[45, 135, 225, 315].map(
+      (θ) =>
+        [
+          node.x + (radius + GP) * Math.sin(θ * Math.PI / 180),
+          node.y + (radius + GP) * Math.cos(θ * Math.PI / 180),
+        ] as [number, number],
+    ),
+    [node.x, y0 - GP],
+    [node.x, y1 + GP],
+    [x0 - GP, node.y],
+    [x1 + GP, node.y],
+  ];
+}
+
+const DefaultGroup: React.FC<GroupProps> = ({ name, nodes }) => {
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  // collect all points to avoid for all nodes
+  const points = nodes.reduce((acc, node) => [...acc, ...getNodePoints(node)], [] as [
+    number,
+    number
+  ][]);
+
+  // Get the convex hull of all points.
+  const polygon = d3.polygonHull(points);
+
+  // Find the cenroid of the convex hull
+  const centroid = d3.polygonCentroid(polygon);
+
+  // Convert the convex hull to a set of points to be used for the surrounding path.
+  const dPoints = polygon.map(
+    (point) => [point[0] - centroid[0], point[1] - centroid[1]] as [number, number],
+  );
+
+  // Find the lowest point of the set in order to place the group label.
+  const lowestPoint = findLowestPoint(dPoints);
+
+  return (
+    <g>
+      <path
+        d={valueline(dPoints)}
+        className="odc-default-group"
+        transform={`translate(${centroid[0]},${centroid[1]})`}
+      />
+      <SvgBoxedText
+        className={'odc-default-group__label'}
+        x={centroid[0] + lowestPoint[0]}
+        y={centroid[1] + lowestPoint[1] + 30}
+        paddingX={20}
+        paddingY={5}
+      >
+        {name}
+      </SvgBoxedText>
+    </g>
+  );
+};
+
+export default DefaultGroup;

--- a/frontend/public/extend/devconsole/components/topology/shapes/DefaultNode.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/DefaultNode.tsx
@@ -3,11 +3,11 @@ import * as React from 'react';
 import { NodeProps } from '../topology-types';
 import BaseNode from './BaseNode';
 
-const DefaultNode: React.FC<NodeProps> = ({ data, x, y, size, selected, onSelect }) => (
+const DefaultNode: React.FC<NodeProps> = ({ x, y, size, selected, onSelect, name }) => (
   <BaseNode
     x={x}
     y={y}
-    label={data.name}
+    label={name}
     outerRadius={size / 2}
     selected={selected}
     onSelect={onSelect}

--- a/frontend/public/extend/devconsole/components/topology/topology-types.ts
+++ b/frontend/public/extend/devconsole/components/topology/topology-types.ts
@@ -42,6 +42,7 @@ export interface Edge {
 
 export interface Group {
   id?: string;
+  type?: string;
   name: string;
   nodes: string[];
 }
@@ -103,6 +104,9 @@ export type ViewNode = {
   x: number;
   y: number;
   size: number;
+  name: string;
+  fx?: number;
+  fy?: number;
 };
 
 export type ViewEdge = {
@@ -112,7 +116,12 @@ export type ViewEdge = {
   target: ViewNode;
 };
 
-export type ViewGroup = Group;
+export type ViewGroup = {
+  id: string;
+  type?: string;
+  name: string;
+  nodes: ViewNode[];
+};
 
 export type NodeProps<D = {}> = ViewNode &
   Selectable & {
@@ -123,10 +132,16 @@ export type EdgeProps<D = {}> = ViewEdge & {
   data?: TopologyDataObject<D>;
 };
 
+export type GroupProps = ViewGroup;
+
 export interface NodeProvider {
   (string): ComponentType<NodeProps>;
 }
 
 export interface EdgeProvider {
   (string): ComponentType<EdgeProps>;
+}
+
+export interface GroupProvider {
+  (string): ComponentType<GroupProps>;
 }

--- a/frontend/public/extend/devconsole/components/topology/topology-utils.ts
+++ b/frontend/public/extend/devconsole/components/topology/topology-utils.ts
@@ -265,7 +265,7 @@ export class TransformTopologyData {
       });
     }
   }
-  
+
   /**
    * sort the deployement version
    */

--- a/frontend/public/extend/devconsole/pages/SourceToImage.tsx
+++ b/frontend/public/extend/devconsole/pages/SourceToImage.tsx
@@ -27,7 +27,7 @@ export const SourceToImagePage: React.FC = () => {
       <div className="co-m-pane__body">
         <h1 className="co-m-pane__heading">{title}</h1>
         <Firehose resources={resources}>
-          <BuildSource preselectedNamespace={preselectedNamespace}/>
+          <BuildSource preselectedNamespace={preselectedNamespace} />
         </Firehose>
       </div>
     </React.Fragment>

--- a/frontend/public/extend/devconsole/shared/components/dropdown/AppDropdown.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/AppDropdown.tsx
@@ -7,10 +7,10 @@ import { Firehose } from '../../../../../components/utils';
 interface AppDropdownProps {
   namespace?: string;
   actionItem?: {
-    actionTitle: string,
-    actionKey: string,
+    actionTitle: string;
+    actionKey: string;
   };
-  selectedKey: string,
+  selectedKey: string;
   onChange?: (name: string, key: string) => void;
 }
 
@@ -27,7 +27,7 @@ const AppDropdown: React.FC<AppDropdownProps> = (props) => {
       namespace: props.namespace,
       kind: 'Deployment',
       prop: 'deployments',
-    }
+    },
   ];
   return (
     <Firehose resources={resources}>

--- a/frontend/public/extend/devconsole/shared/components/svg/SvgBoxedText.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/SvgBoxedText.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import SvgDropShadowFilter from './SvgDropShadowFilter';
+
+interface State {
+  bb: SVGRect;
+}
+
+export type SvgBoxedTextProps = {
+  children: string;
+  className: string;
+  paddingX: number;
+  paddingY: number;
+  x: number;
+  y: number;
+  cornerRadius?: number;
+};
+
+const FILTER_ID = 'SvgBoxedTextDropShadowFilterId';
+
+/**
+ * Renders a `<text>` component with a `<rect>` box behind.
+ */
+export default class SvgBoxedText extends React.PureComponent<SvgBoxedTextProps, State> {
+  state: State = {
+    bb: null,
+  };
+
+  textRef = React.createRef<SVGTextElement>();
+
+  componentDidMount() {
+    this.computeBoxSize();
+  }
+
+  componentDidUpdate({ children }: SvgBoxedTextProps) {
+    if (this.props.children !== children) {
+      this.computeBoxSize();
+    }
+  }
+
+  private computeBoxSize() {
+    this.setState({ bb: this.textRef.current.getBBox() });
+  }
+
+  render() {
+    const {
+      children,
+      className,
+      paddingX,
+      paddingY,
+      cornerRadius = 4,
+      x,
+      y,
+      ...other
+    } = this.props;
+    const { bb } = this.state;
+    return (
+      <g className={className}>
+        <SvgDropShadowFilter id={FILTER_ID} />
+        {bb && (
+          <rect
+            filter={`url(#${FILTER_ID})`}
+            x={x - paddingX - bb.width / 2}
+            width={bb.width + paddingX * 2}
+            y={y - paddingY - bb.height / 2}
+            height={bb.height + paddingY * 2}
+            rx={cornerRadius}
+            ry={cornerRadius}
+          />
+        )}
+        <text {...other} ref={this.textRef} x={x} y={y} textAnchor="middle" dy="0.3em">
+          {children}
+        </text>
+      </g>
+    );
+  }
+}

--- a/frontend/public/extend/devconsole/shared/components/svg/SvgDefsProvider.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/SvgDefsProvider.tsx
@@ -20,7 +20,7 @@ class Defs extends React.PureComponent<{}, DefsState> {
 
   setDefs(defs: DefsMap) {
     // setting the state will re-render this component
-    this.setState({ defs });
+    this.setState({ defs: { ...defs } });
   }
 
   render() {


### PR DESCRIPTION
* Added group outline with label to topology.
* Multiple groups WILL intersect. There is no special handling to ensure groups are repelled from each other. The current layout is too simplistic to support this. Although this is a good first pass.
* Group label always remains at the bottom most point of the outline.
* Groups are draggable and move all nodes within the group together.

![topology-groups](https://user-images.githubusercontent.com/14068621/56940298-78e27580-6adb-11e9-9d90-726648ac3d4b.gif)
