### PR TITLE
source topology icons from existing catalog-item-icon map

### DIFF
--- a/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import SvgDropShadowFilter from '../../../shared/components/svg/SvgDropShadowFilter';
+import { getImageForIconClass } from '../../../../../components/catalog/catalog-item-icon';
 import './BaseNode.scss';
 
 type BaseNodeProps = {
@@ -47,8 +48,7 @@ const BaseNode: React.FunctionComponent<BaseNodeProps> = ({
         y={-innerRadius}
         width={innerRadius * 2}
         height={innerRadius * 2}
-        xlinkHref={icon ? `/static/assets/${icon}.svg` : '/static/assets/openshift.svg'}
-        onError={(e) => e.currentTarget.setAttribute('xlink:href', '/static/assets/openshift.svg')}
+        xlinkHref={getImageForIconClass(`icon-${icon}`) || getImageForIconClass('icon-openshift')}
       />
       <text
         className={`odc-base-node__label ${selected ? 'is-selected' : ''}`}


### PR DESCRIPTION
Console has a class called `catalog-item-icon` that has a map of icon name to icon URL.

We should be using this class instead of pointing directly to icons inside the `/static` dir because those icons only exist when webpack imports the icons due to code referencing them. And the only code currently referencing these icons is `catalog-item-icon`.

This also makes handling the error case where an invalid icon was supplied easier.