### PR TITLE
handle invalid connects-to value gracefully

### DIFF
--- a/frontend/public/extend/devconsole/components/topology/topology-utils.ts
+++ b/frontend/public/extend/devconsole/components/topology/topology-utils.ts
@@ -220,13 +220,14 @@ export class TransformTopologyData {
       const totalDeployments = _.cloneDeep(
         _.concat(this.resources.deploymentConfigs.data, this.resources.deployments.data),
       );
-      // // find and add the edges for a node
+      // find and add the edges for a node
       if (_.has(annotations, 'app.openshift.io/connects-to')) {
         try {
           edges = JSON.parse(annotations['app.openshift.io/connects-to']);
         } catch (e) {
-          //connects-to annotation should hold a JSON string value
-          throw new Error('Invalid connects-to annotation provided');
+          // connects-to annotation should hold a JSON string value but failed to parse
+          // treat value as a comma separated list of strings
+          edges = annotations['app.openshift.io/connects-to'].split(',').map((v) => v.trim());
         }
         _.map(edges, (edge) => {
           //handles multiple edges


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-679

When the `connects-to` label value is incorrectly entered and the JSON fails to parse, an error was thrown resulting in a blank page and console errors. This change no longer throws the error and instead treats the value as comma separated string. If an invalid value is now entered, the worse that will happen is that no connection will be shown. If the user forgot to put the value in a JSON array but instead entered the name as a list of strings, the connection will work.