### PR TITLE
fix svg filter references in safari

### DIFF
--- a/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.scss
+++ b/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.scss
@@ -1,4 +1,8 @@
 .odc-base-node {
+  &__bg {
+    fill: #fff;
+  }
+
   &__selection {
     fill: none;
     stroke: var(--pf-global--active-color--300);

--- a/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import SvgDropShadowFilter from '../../../shared/components/svg/SvgDropShadowFilter';
 import { getImageForIconClass } from '../../../../../components/catalog/catalog-item-icon';
+import { createFilterIdUrl } from '../../../shared/utils/svg-utils';
 import './BaseNode.scss';
 
 type BaseNodeProps = {
@@ -42,7 +43,13 @@ const BaseNode: React.FunctionComponent<BaseNodeProps> = ({
       }
     >
       <SvgDropShadowFilter id={FILTER_ID} />
-      <circle cx={0} cy={0} r={outerRadius} fill="#fff" filter={`url(#${FILTER_ID})`} />
+      <circle
+        className="odc-base-node__bg"
+        cx={0}
+        cy={0}
+        r={outerRadius}
+        filter={createFilterIdUrl(FILTER_ID)}
+      />
       <image
         x={-innerRadius}
         y={-innerRadius}

--- a/frontend/public/extend/devconsole/components/topology/shapes/Decorator.scss
+++ b/frontend/public/extend/devconsole/components/topology/shapes/Decorator.scss
@@ -2,6 +2,10 @@
   color: var(--pf-global--Color--200);
   transition: color 0.2s ease;
 
+  &__bg {
+    fill: #fff;
+  }
+
   &:hover,
   &:active {
     color: var(--pf-global--link--Color--hover);

--- a/frontend/public/extend/devconsole/components/topology/shapes/Decorator.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/Decorator.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import SvgDropShadowFilter from '../../../shared/components/svg/SvgDropShadowFilter';
+import { createFilterIdUrl } from '../../../shared/utils/svg-utils';
 import './Decorator.scss';
 
 type DecoratorTypes = {
@@ -14,6 +15,7 @@ type DecoratorTypes = {
 };
 
 const FILTER_ID = 'DecoratorDropShadowFilterId';
+
 const Decorator: React.FunctionComponent<DecoratorTypes> = ({
   x,
   y,
@@ -39,7 +41,13 @@ const Decorator: React.FunctionComponent<DecoratorTypes> = ({
     >
       <SvgDropShadowFilter id={FILTER_ID} floodOpacity={0.5} />
       <title>{title}</title>
-      <circle cx={0} cy={0} r={radius} fill="#fff" filter={`url(#${FILTER_ID})`} />
+      <circle
+        className="odc-decorator__bg"
+        cx={0}
+        cy={0}
+        r={radius}
+        filter={createFilterIdUrl(FILTER_ID)}
+      />
       {children}
     </g>
   );

--- a/frontend/public/extend/devconsole/shared/components/svg/SvgBoxedText.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/SvgBoxedText.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import SvgDropShadowFilter from './SvgDropShadowFilter';
+import { createFilterIdUrl } from '../../utils/svg-utils';
 
 interface State {
   bb: SVGRect;
@@ -59,7 +60,7 @@ export default class SvgBoxedText extends React.PureComponent<SvgBoxedTextProps,
         <SvgDropShadowFilter id={FILTER_ID} />
         {bb && (
           <rect
-            filter={`url(#${FILTER_ID})`}
+            filter={createFilterIdUrl(FILTER_ID)}
             x={x - paddingX - bb.width / 2}
             width={bb.width + paddingX * 2}
             y={y - paddingY - bb.height / 2}

--- a/frontend/public/extend/devconsole/shared/utils/svg-utils.ts
+++ b/frontend/public/extend/devconsole/shared/utils/svg-utils.ts
@@ -1,0 +1,3 @@
+export function createFilterIdUrl(id: string): string {
+  return `url(${`${location.pathname}${location.search}`}#${id})`;
+}


### PR DESCRIPTION
Fixes:
https://jira.coreos.com/browse/ODC-700
https://jira.coreos.com/browse/ODC-701

Safari resolves url references differently (apparently more correctly adheres to the spec) than chrome. Since the page sets a `<base href="/">`, the filter references were failing to resolve in safari. Address the issue by creating filter ID references that contain the full location path name and query. This has resolved drop shadows not showing up. When the filter failed to load, the fill also failed to apply which is why connectors were shown through the node.

![image](https://user-images.githubusercontent.com/14068621/57032844-4c347800-6c19-11e9-9f03-178f0f712adc.png)
