### PR TITLE
fix(dev-routes): disable shared dev routes when devconsole is disabled

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -102,7 +102,7 @@ const DefaultPage = connect(mapPerspectiveStateToProps)(
 
     if (openshiftFlag) {
       // TODO - We should be using the link utility to create these links with perspective.
-      return lastViewedPerspective && flags[FLAGS.SHOW_DEV_CONSOLE] && lastViewedPerspective !== 'admin' ? (
+      return lastViewedPerspective && lastViewedPerspective !== 'admin' ? (
         <Redirect to={`/${lastViewedPerspective}`} />
       ) : (
         <Redirect to="/k8s/cluster/projects" />
@@ -126,7 +126,10 @@ class App extends React.PureComponent {
     this._onResize = this._onResize.bind(this);
     this._onPerspectiveSwitcherClose = this._onPerspectiveSwitcherClose.bind(this);
     this.previousDesktopState = this._isDesktop();
-
+    this.perspectiveMap = {
+      admin: FLAGS.OPENSHIFT,
+      dev: FLAGS.SHOW_DEV_CONSOLE
+    }
     this.state = {
       isNavOpen: this._isDesktop(),
       isPerspectiveSwitcherOpen : false,
@@ -208,7 +211,8 @@ class App extends React.PureComponent {
 
   _prependActivePerspective(path) {
     const { flags, activePerspective } = this.props;
-    if(flags && !flagPending(FLAGS.SHOW_DEV_CONSOLE) && flags.SHOW_DEV_CONSOLE && activePerspective === 'dev') {
+    const activePerspectiveFlag = flags[this.perspectiveMap[activePerspective]];
+    if(activePerspective !== 'admin' && flags && !flagPending(activePerspectiveFlag) && activePerspectiveFlag) {
       return pathWithPerspective(activePerspective, path);
     }
     return path;

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -42,7 +42,7 @@ import 'url-search-params-polyfill';
 // Extensions
 import devConsoleRoutes from '../extend/devconsole/routes';
 import PerspectiveSwitcher from '../extend/devconsole/shared/components/PerspectiveSwitcher';
-import { pathWithPerspective } from './utils/perspective';
+import { pathWithPerspective, PerspectiveFlagMap } from './utils/perspective';
 
 // React Router's proptypes are incorrect. See https://github.com/ReactTraining/react-router/pull/5393
 Route.propTypes.path = PropTypes.oneOfType([
@@ -126,10 +126,6 @@ class App extends React.PureComponent {
     this._onResize = this._onResize.bind(this);
     this._onPerspectiveSwitcherClose = this._onPerspectiveSwitcherClose.bind(this);
     this.previousDesktopState = this._isDesktop();
-    this.perspectiveMap = {
-      admin: FLAGS.OPENSHIFT,
-      dev: FLAGS.SHOW_DEV_CONSOLE
-    }
     this.state = {
       isNavOpen: this._isDesktop(),
       isPerspectiveSwitcherOpen : false,
@@ -211,8 +207,8 @@ class App extends React.PureComponent {
 
   _prependActivePerspective(path) {
     const { flags, activePerspective } = this.props;
-    const activePerspectiveFlag = flags[this.perspectiveMap[activePerspective]];
-    if(activePerspective !== 'admin' && flags && !flagPending(activePerspectiveFlag) && activePerspectiveFlag) {
+    const activePerspectiveFlag = flags[PerspectiveFlagMap[activePerspective]];
+    if(flags && !flagPending(activePerspectiveFlag) && activePerspectiveFlag) {
       return pathWithPerspective(activePerspective, path);
     }
     return path;

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -93,10 +93,10 @@ const mapPerspectiveStateToProps = (state) => {
 
 // The default page component lets us connect to flags without connecting the entire App.
 const DefaultPage = connect(mapPerspectiveStateToProps)(
-  connectToFlags(FLAGS.OPENSHIFT)(({ flags }) => {
+  connectToFlags(FLAGS.OPENSHIFT)(({ flags, activePerspective }) => {
     const openshiftFlag = flags[FLAGS.OPENSHIFT];
     const lastViewedPerspective = localStorage.getItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY);
-    if (flagPending(openshiftFlag) && flagPending(flags[FLAGS.SHOW_DEV_CONSOLE])) {
+    if (flagPending(openshiftFlag) || (activePerspective === 'dev' && flagPending(flags[FLAGS.SHOW_DEV_CONSOLE]))) {
       return <Loading />;
     }
 
@@ -207,18 +207,18 @@ class App extends React.PureComponent {
 
   _prependActivePerspective(path) {
     const { flags, activePerspective } = this.props;
-    const activePerspectiveFlag = flags[PerspectiveFlagMap[activePerspective]];
-    if(flags && !flagPending(activePerspectiveFlag) && activePerspectiveFlag) {
+    const activePerspectiveFlagEnabled = flags[PerspectiveFlagMap[activePerspective]];
+    if (flags && !flagPending(activePerspectiveFlagEnabled) && activePerspectiveFlagEnabled) {
       return pathWithPerspective(activePerspective, path);
     }
     return path;
   }
 
-  _handlePageNotFound(props) {
-   if (flagPending(props.flags[FLAGS.SHOW_DEV_CONSOLE])) {
-      return <Route component={null}/>;
-   }
-   return <LazyRoute loader={() => import('./error' /* webpackChunkName: "error" */).then(m => m.ErrorPage404)} />
+  _handlePageNotFound({ flags, activePerspective }) {
+    if (activePerspective === 'dev' && flagPending(flags[FLAGS.SHOW_DEV_CONSOLE])) {
+      return <Route component={null} />;
+    }
+    return <LazyRoute loader={() => import('./error' /* webpackChunkName: "error" */).then(m => m.ErrorPage404)} />;
   }
 
   render() {

--- a/frontend/public/components/utils/perspective.tsx
+++ b/frontend/public/components/utils/perspective.tsx
@@ -2,6 +2,7 @@ import { getActivePerspective } from '../../ui/ui-selectors';
 import { FLAGS } from '../../features';
 import store from '../../redux';
 
+/* eslint-disable no-unused-vars, no-undef */
 export enum PerspectiveFlagMap {
   admin = FLAGS.OPENSHIFT,
   dev = FLAGS.SHOW_DEV_CONSOLE

--- a/frontend/public/components/utils/perspective.tsx
+++ b/frontend/public/components/utils/perspective.tsx
@@ -1,5 +1,11 @@
 import { getActivePerspective } from '../../ui/ui-selectors';
+import { FLAGS } from '../../features';
 import store from '../../redux';
+
+export enum PerspectiveFlagMap {
+  admin = FLAGS.OPENSHIFT,
+  dev = FLAGS.SHOW_DEV_CONSOLE
+}
 
 // FIXME - Remove use of global redux store.
 export const pathWithPerspectiveFromStore = path => {


### PR DESCRIPTION
Fixes:
https://jira.coreos.com/browse/ODC-546

1. Page content area should display 404 because dev console is not enabled.
2. Does not load the 404 content until both console and dev-console feature flags are resolved.
