### PR TITLE
fix(devconsolenav): Redo isActive logic using react-router

### DIFF
--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -32,7 +32,7 @@ export const matchesModel = (resourcePath, model) => model && matchesPath(resour
 import { Nav, NavExpandable, NavItem, NavList, PageSidebar } from '@patternfly/react-core';
 import PerspectiveLink from '../extend/devconsole/shared/components/PerspectiveLink';
 
-const stripNS = href => {
+export const stripNS = href => {
   href = stripBasePath(href);
   return href.replace(/^\/?k8s\//, '').replace(/^\/?(cluster|all-namespaces|ns\/[^/]*)/, '').replace(/^\//, '');
 };
@@ -132,7 +132,7 @@ ResourceClusterLink.propTypes = {
 
 export class HrefLink extends NavLink {
   static isActive(props, resourcePath) {
-    const noNSHref = stripNS(props.href);
+    const noNSHref = stripNS(stripPerspectivePath(props.href));
     return resourcePath === noNSHref || _.startsWith(resourcePath, `${noNSHref}/`);
   }
 

--- a/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
+++ b/frontend/public/extend/devconsole/components/DevConsoleNav.tsx
@@ -6,6 +6,7 @@ import { Nav, NavList, PageSidebar } from '@patternfly/react-core';
 import { HrefLink, NavSection, ResourceClusterLink, ResourceNSLink } from '../../../components/nav';
 import { FLAGS } from '../../../features';
 import { BuildModel, PipelineModel } from '../../../models';
+import { stripPerspectivePath } from '../../../components/utils/link';
 
 interface DevConsoleNavigationProps {
   isNavOpen: boolean;
@@ -30,7 +31,9 @@ export const PageNav = (props: DevConsoleNavigationProps) => {
     let matchflag: boolean = false;
     paths.map(
       (path) =>
-        (matchflag = matchflag || matchPath(stripNSFromPath(props.location), { path }) != null),
+        (matchflag =
+          matchflag ||
+          matchPath(stripPerspectivePath(stripNSFromPath(props.location)), { path }) != null),
     );
     return matchflag;
   };
@@ -42,31 +45,25 @@ export const PageNav = (props: DevConsoleNavigationProps) => {
           href="/add"
           name="+Add"
           activePath="/dev/add"
-          isActive={isActive([
-            '/dev/add',
-            '/dev/import',
-            '/dev/catalog',
-            '/dev/k8s/import',
-            '/dev/deploy-image',
-          ])}
+          isActive={isActive(['/add', '/import', '/catalog', '/k8s/import', '/deploy-image'])}
         />
         <HrefLink
           href="/topology"
           name="Topology"
           activePath="/dev/topology"
-          isActive={isActive(['/dev/topology'])}
+          isActive={isActive(['/topology'])}
         />
         <ResourceNSLink
           resource="buildconfigs"
           name={BuildModel.labelPlural}
           activeNamespace={props.activeNamespace}
-          isActive={isActive(['/dev/k8s/buildconfigs'])}
+          isActive={isActive(['/k8s/buildconfigs'])}
         />
         <ResourceNSLink
           resource="pipelines"
           name={PipelineModel.labelPlural}
           activeNamespace={props.activeNamespace}
-          isActive={isActive(['/dev/k8s/pipelines', '/dev/k8s/pipelineruns'])}
+          isActive={isActive(['/k8s/pipelines', '/k8s/pipelineruns'])}
         />
         <DevNavSection title="Advanced">
           <ResourceClusterLink resource="projects" name="Projects" required={FLAGS.OPENSHIFT} />


### PR DESCRIPTION
@christianvogt @rohitkrai03 @divyanshiGupta @debsmita1 Please review the PR.

> Fixes bug https://jira.coreos.com/browse/ODC-620

**Note:**

- Re-implemented the stripNS function as the function from openshift console ( frontend/public/components/nav.jsx ) is not working on these routes.
- Re-implemented the isActive logic using react-router: matchPath instead of reusing existing logic from console which does string matching operations
- Activated the +Add nav for import, import from yaml, add database and deploy-image. 