### PR TITLE
update workload node visuals

### DIFF
--- a/frontend/public/extend/devconsole/components/topology/Graph.tsx
+++ b/frontend/public/extend/devconsole/components/topology/Graph.tsx
@@ -71,7 +71,7 @@ export default class Graph extends React.Component<GraphProps, State> {
       <div ref={measureRef} className="odc-graph">
         {dimensions && (
           <Renderer
-            nodeSize={125}
+            nodeSize={90}
             height={dimensions.height}
             width={dimensions.width}
             graph={graph}

--- a/frontend/public/extend/devconsole/components/topology/Graph.tsx
+++ b/frontend/public/extend/devconsole/components/topology/Graph.tsx
@@ -71,7 +71,7 @@ export default class Graph extends React.Component<GraphProps, State> {
       <div ref={measureRef} className="odc-graph">
         {dimensions && (
           <Renderer
-            nodeSize={90}
+            nodeSize={104}
             height={dimensions.height}
             width={dimensions.width}
             graph={graph}

--- a/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.scss
+++ b/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.scss
@@ -1,6 +1,6 @@
 .odc-base-node {
   &__bg {
-    fill: #fff;
+    fill: var(--pf-global--BackgroundColor--light-100);
   }
 
   &__selection {
@@ -10,11 +10,7 @@
 
   &__label {
     pointer-events: none;
-    fill: var(--pf-global--Color--100);
-    font-size: var(--pf-global--FontSize--md);
-
-    &.is-selected {
-      fill: var(--pf-global--active-color--300);
-    }
+    fill: var(--pf-global--Color--300);
+    font-size: var(--pf-global--FontSize--sm);
   }
 }

--- a/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.tsx
@@ -5,7 +5,11 @@ import { getImageForIconClass } from '../../../../../components/catalog/catalog-
 import { createFilterIdUrl } from '../../../shared/utils/svg-utils';
 import './BaseNode.scss';
 
-type BaseNodeProps = {
+interface State {
+  hover?: boolean;
+}
+
+export interface BaseNodeProps {
   x?: number;
   y?: number;
   outerRadius: number;
@@ -15,69 +19,84 @@ type BaseNodeProps = {
   icon?: string;
   label?: string;
   children?: React.ReactNode;
-};
+  attachments?: React.ReactNode;
+}
 
 const FILTER_ID = 'BaseNodeDropShadowFilterId';
+const FILTER_ID_HOVER = 'BaseNodeDropShadowFilterId--hover';
 
-const BaseNode: React.FunctionComponent<BaseNodeProps> = ({
-  x = 0,
-  y = 0,
-  outerRadius,
-  innerRadius = outerRadius / 1.4,
-  selected,
-  icon,
-  label,
-  onSelect,
-  children,
-}: BaseNodeProps) => {
-  return (
-    <g
-      transform={`translate(${x}, ${y})`}
-      onClick={
-        onSelect
-          ? (e) => {
-            e.stopPropagation();
-            onSelect();
+export default class BaseNode extends React.Component<BaseNodeProps, State> {
+  state: State = {};
+
+  render() {
+    const {
+      x = 0,
+      y = 0,
+      outerRadius,
+      innerRadius = outerRadius / 1.4,
+      selected,
+      icon,
+      label,
+      onSelect,
+      children,
+      attachments,
+    } = this.props;
+    const { hover } = this.state;
+
+    return (
+      <g transform={`translate(${x}, ${y})`}>
+        <g
+          onClick={
+            onSelect
+              ? (e) => {
+                e.stopPropagation();
+                onSelect();
+              }
+              : null
           }
-          : null
-      }
-    >
-      <SvgDropShadowFilter id={FILTER_ID} />
-      <circle
-        className="odc-base-node__bg"
-        cx={0}
-        cy={0}
-        r={outerRadius}
-        filter={createFilterIdUrl(FILTER_ID)}
-      />
-      <image
-        x={-innerRadius}
-        y={-innerRadius}
-        width={innerRadius * 2}
-        height={innerRadius * 2}
-        xlinkHref={getImageForIconClass(`icon-${icon}`) || getImageForIconClass('icon-openshift')}
-      />
-      <text
-        className={`odc-base-node__label ${selected ? 'is-selected' : ''}`}
-        textAnchor="middle"
-        y={outerRadius + 10}
-        x={0}
-        dy="0.6em"
-      >
-        {label}
-      </text>
-      {selected && (
-        <circle
-          className="odc-base-node__selection"
-          cx={0}
-          cy={0}
-          r={outerRadius + 1}
-          strokeWidth={2}
-        />
-      )}
-      {children}
-    </g>
-  );
-};
-
-export default BaseNode;
+          onMouseEnter={() => this.setState({ hover: true })}
+          onMouseLeave={() => this.setState({ hover: false })}
+        >
+          <SvgDropShadowFilter id={FILTER_ID} />
+          <SvgDropShadowFilter id={FILTER_ID_HOVER} dy={3} stdDeviation={7} floodOpacity={0.24} />
+          <circle
+            className="odc-base-node__bg"
+            cx={0}
+            cy={0}
+            r={outerRadius}
+            filter={hover ? createFilterIdUrl(FILTER_ID_HOVER) : createFilterIdUrl(FILTER_ID)}
+          />
+          <image
+            x={-innerRadius}
+            y={-innerRadius}
+            width={innerRadius * 2}
+            height={innerRadius * 2}
+            xlinkHref={
+              getImageForIconClass(`icon-${icon}`) || getImageForIconClass('icon-openshift')
+            }
+          />
+          <text
+            className="odc-base-node__label"
+            textAnchor="middle"
+            y={outerRadius + 10}
+            x={0}
+            dy="0.6em"
+          >
+            {label}
+          </text>
+          {selected && (
+            <circle
+              className="odc-base-node__selection"
+              cx={0}
+              cy={0}
+              r={outerRadius + 1}
+              strokeWidth={2}
+            />
+          )}
+          {children}
+        </g>
+        {attachments}
+      </g>
+    );
+  }
+}

--- a/frontend/public/extend/devconsole/components/topology/shapes/Decorator.scss
+++ b/frontend/public/extend/devconsole/components/topology/shapes/Decorator.scss
@@ -3,7 +3,7 @@
   transition: color 0.2s ease;
 
   &__bg {
-    fill: #fff;
+    fill: var(--pf-global--BackgroundColor--light-100);
   }
 
   &:hover,

--- a/frontend/public/extend/devconsole/components/topology/shapes/Decorator.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/Decorator.tsx
@@ -35,7 +35,7 @@ const Decorator: React.FunctionComponent<DecoratorTypes> = ({
         onClick && onClick();
       }}
     >
-      <SvgDropShadowFilter id={FILTER_ID} floodOpacity={0.5} />
+      <SvgDropShadowFilter id={FILTER_ID} stdDeviation={1} floodOpacity={0.5} />
       <title>{title}</title>
       <circle
         className="odc-decorator__bg"

--- a/frontend/public/extend/devconsole/components/topology/shapes/PodStatus.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/PodStatus.tsx
@@ -53,7 +53,7 @@ export default class PodStatus extends React.PureComponent<PodStatusProps> {
     const arcFunc = arc()
       .outerRadius(outerRadius)
       .innerRadius(innerRadius)
-      .padAngle(0.01);
+      .padAngle(0.02);
 
     const pieData = pieFunc(podData);
 

--- a/frontend/public/extend/devconsole/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/WorkloadNode.tsx
@@ -15,8 +15,8 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
   onSelect,
 }) => {
   const radius = size / 2;
-  const podStatusStrokeWidth = radius * 0.15;
-  const podStatusInset = podStatusStrokeWidth / 2;
+  const podStatusStrokeWidth = 8 / 90 * size;
+  const podStatusInset = 5 / 90 * size;
   const podStatusOuterRadius = radius - podStatusInset;
   const podStatusInnerRadius = podStatusOuterRadius - podStatusStrokeWidth;
   const decoratorRadius = radius * 0.25;
@@ -30,40 +30,44 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
       label={workload.name}
       selected={selected}
       onSelect={onSelect}
+      attachments={[
+        workload.data.editUrl && (
+          <Decorator
+            key="edit"
+            x={radius - decoratorRadius * 0.75}
+            y={radius - decoratorRadius * 0.75}
+            radius={decoratorRadius}
+            href={workload.data.editUrl}
+            external
+            title="Edit Source Code"
+          >
+            <g transform={`translate(-${decoratorRadius / 2}, -${decoratorRadius / 2})`}>
+              <PenIcon style={{ fontSize: decoratorRadius }} />
+            </g>
+          </Decorator>
+        ),
+        workload.data.url && (
+          <Decorator
+            key="route"
+            x={radius - decoratorRadius * 0.75}
+            y={-radius + decoratorRadius * 0.75}
+            radius={decoratorRadius}
+            href={workload.data.url}
+            external
+            title="Open URL"
+          >
+            <g transform={`translate(-${decoratorRadius / 2}, -${decoratorRadius / 2})`}>
+              <ExternalLinkAltIcon style={{ fontSize: decoratorRadius }} />
+            </g>
+          </Decorator>
+        ),
+      ]}
     >
       <PodStatus
         innerRadius={podStatusInnerRadius}
         outerRadius={podStatusOuterRadius}
         pods={workload.data.donutStatus.pods}
       />
-      {workload.data.editUrl && (
-        <Decorator
-          x={radius - decoratorRadius}
-          y={radius - decoratorRadius}
-          radius={decoratorRadius}
-          href={workload.data.editUrl}
-          external
-          title="Edit Source Code"
-        >
-          <g transform={`translate(-${decoratorRadius / 2}, -${decoratorRadius / 2})`}>
-            <PenIcon style={{ fontSize: decoratorRadius }} />
-          </g>
-        </Decorator>
-      )}
-      {workload.data.url && (
-        <Decorator
-          x={radius - decoratorRadius}
-          y={-radius + decoratorRadius}
-          radius={decoratorRadius}
-          href={workload.data.url}
-          external
-          title="Open URL"
-        >
-          <g transform={`translate(-${decoratorRadius / 2}, -${decoratorRadius / 2})`}>
-            <ExternalLinkAltIcon style={{ fontSize: decoratorRadius }} />
-          </g>
-        </Decorator>
-      )}
     </BaseNode>
   );
 };

--- a/frontend/public/extend/devconsole/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/WorkloadNode.tsx
@@ -15,8 +15,8 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
   onSelect,
 }) => {
   const radius = size / 2;
-  const podStatusStrokeWidth = 8 / 90 * size;
-  const podStatusInset = 5 / 90 * size;
+  const podStatusStrokeWidth = 8 / 104 * size;
+  const podStatusInset = 5 / 104 * size;
   const podStatusOuterRadius = radius - podStatusInset;
   const podStatusInnerRadius = podStatusOuterRadius - podStatusStrokeWidth;
   const decoratorRadius = radius * 0.25;
@@ -31,11 +31,11 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
       selected={selected}
       onSelect={onSelect}
       attachments={[
-        workload.data.editUrl && (
+        workload.data.url && (
           <Decorator
             key="edit"
-            x={radius - decoratorRadius * 0.75}
-            y={radius - decoratorRadius * 0.75}
+            x={radius - decoratorRadius * 0.7}
+            y={radius - decoratorRadius * 0.7}
             radius={decoratorRadius}
             href={workload.data.editUrl}
             external
@@ -49,8 +49,8 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
         workload.data.url && (
           <Decorator
             key="route"
-            x={radius - decoratorRadius * 0.75}
-            y={-radius + decoratorRadius * 0.75}
+            x={radius - decoratorRadius * 0.7}
+            y={-radius + decoratorRadius * 0.7}
             radius={decoratorRadius}
             href={workload.data.url}
             external

--- a/frontend/public/extend/devconsole/shared/components/svg/SvgDropShadowFilter.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/SvgDropShadowFilter.tsx
@@ -17,9 +17,9 @@ const SvgDropShadowFilter: React.FC<SvgDropShadowFilterProps> = ({
   id,
   dx = 0,
   dy = 1,
-  stdDeviation = 1,
+  stdDeviation = 2,
   floodColor = '#030303',
-  floodOpacity = 0.15,
+  floodOpacity = 0.2,
 }) => (
   <SvgDefs id={id}>
     <filter


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-732

- Adjust size of node to 104px
- Increased padAngle to give more whitespace between pod segments
- Gap between outer radius and pods set to 5px
- Pod segment width set to 8px
- Use patternfly variables for css colors and align colors with ux design
- Update selected state of node to only add colored ring and not update label color
- Update drop shadows to align with patternfly
- Added larger drop shadow to node on hover. Hovering the decorators does not add hover shadow to node.
- Moved decorators further out as to not overlap the pod segments.

Hover and no hover:
![image](https://user-images.githubusercontent.com/14068621/57164488-4201ad80-6dc2-11e9-986b-0e084507316a.png)
Selected:
![image](https://user-images.githubusercontent.com/14068621/57164498-4d54d900-6dc2-11e9-9634-c07b1963d41b.png)
Hover and selected:
![image](https://user-images.githubusercontent.com/14068621/57164505-52198d00-6dc2-11e9-83c1-6e042eb5adf3.png)
Decorator hover:
![image](https://user-images.githubusercontent.com/14068621/57164550-76756980-6dc2-11e9-8776-1fa9d5b4b111.png)

