### PR TITLE
add namespace scope to pipeline runs tab

### DIFF
--- a/frontend/public/extend/devconsole/components/pipelines/PipelineRuns.tsx
+++ b/frontend/public/extend/devconsole/components/pipelines/PipelineRuns.tsx
@@ -31,6 +31,7 @@ class PipelineRuns extends React.Component<PipelineRunsProps> {
         showTitle={false}
         canCreate={false}
         kind="PipelineRun"
+        namespace={this.props.obj.metadata.namespace}
         selector={selector}
         ListComponent={PipelineRunsList}
         rowFilters={filters}


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-733

Adds the `namespace` to the `ListPage` to ensure the selector is properly scoped.