### PR TITLE
Fix issue in git import form when all namespace is selected

### DIFF
--- a/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-undef */
 import * as React from 'react';
-import { connect } from 'react-redux';
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash-es';
 import { Form, FormControl, FormGroup, ControlLabel, HelpBlock, Button } from 'patternfly-react';
@@ -599,9 +598,4 @@ export class ImportFlowForm extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    activeNamespace: state.UI.get('activeNamespace'),
-  };
-};
-export default connect(mapStateToProps)(ImportFlowForm);
+export default ImportFlowForm;

--- a/frontend/public/extend/devconsole/components/import/ImportFlow.tsx
+++ b/frontend/public/extend/devconsole/components/import/ImportFlow.tsx
@@ -3,11 +3,14 @@ import { Firehose } from '../../../../components/utils';
 import { ImageStreamModel } from '../../../../models';
 import ImportFlowForm from '../ImportFlowForm/ImportFlowForm';
 
-export const ImportFlow: React.FunctionComponent = () => {
+interface ImportFlowProps {
+  namespace: string;
+}
 
+export const ImportFlow: React.FunctionComponent<ImportFlowProps> = ({ namespace }) => {
   return (
-    <Firehose resources={[{kind: ImageStreamModel.kind, prop: 'imagestreams', isList: true}]}>
-      <ImportFlowForm />
+    <Firehose resources={[{ kind: ImageStreamModel.kind, prop: 'imagestreams', isList: true }]}>
+      <ImportFlowForm activeNamespace={namespace} />
     </Firehose>
   );
 };

--- a/frontend/public/extend/devconsole/pages/Import.tsx
+++ b/frontend/public/extend/devconsole/pages/Import.tsx
@@ -1,18 +1,26 @@
 import * as React from 'react';
+import { match as RMatch } from 'react-router';
 import { Helmet } from 'react-helmet';
 import { ImportFlow } from './../components/import/ImportFlow';
 import { PageHeading } from '../../../components/utils';
 
-const ImportPage: React.FunctionComponent = () => (
-  <React.Fragment>
-    <Helmet>
-      <title>Import from git</title>
-    </Helmet>
-    <PageHeading title="Git Import" />
-    <div className="co-m-pane__body">
-      <ImportFlow />
-    </div>
-  </React.Fragment>
-);
+export interface ImportPageProps {
+  match: RMatch<{ ns?: string }>;
+}
+
+const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match }) => {
+  const namespace = match.params.ns;
+  return (
+    <React.Fragment>
+      <Helmet>
+        <title>Import from git</title>
+      </Helmet>
+      <PageHeading title="Git Import" />
+      <div className="co-m-pane__body">
+        <ImportFlow namespace={namespace} />
+      </div>
+    </React.Fragment>
+  );
+};
 
 export default ImportPage;


### PR DESCRIPTION
Fixes - https://jira.coreos.com/browse/ODC-734

- Earlier `activeNamespace` was taken from the redux store to pass it as a prop to `ImportFlowForm` which is why when `ALL_NAMESPACE` was selected from project selector, `activeNamespace` would be equal to `#ALL_NS#` key. This when passes to the dropdowns for getting resources would result in an error and dropdowns will never show any resource list.
- Uses `ns` match from the URL and passes it down to `ImportFlowForm` component. 
- So when `ALL_NAMESPACE` is selected the `ns` part is undefined which fixes the issues of passing `#ALL_NS#` to the dropdowns.