### PR TITLE
truncate node labels on topology

### DIFF
--- a/frontend/public/extend/devconsole/components/import/ImportFlow.tsx
+++ b/frontend/public/extend/devconsole/components/import/ImportFlow.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import { Firehose } from '../../../../components/utils';
 import { ImageStreamModel } from '../../../../models';

--- a/frontend/public/extend/devconsole/components/topology/__tests__/TopologySideBar.spec.tsx
+++ b/frontend/public/extend/devconsole/components/topology/__tests__/TopologySideBar.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-unused-vars no-undef */
+/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { TopologyDataObject } from './../topology-types';
@@ -6,7 +6,6 @@ import SideBar, { TopologySideBarProps } from './../TopologySideBar';
 import { CloseButton } from '../../../../../components/utils';
 
 describe('TopologySideBar:', () => {
-
   const props = {
     show: true,
     item: {
@@ -23,7 +22,11 @@ describe('TopologySideBar:', () => {
   it('clicking on close button should call the onClose callback function', () => {
     const onClose = jest.fn();
     const wrapper = shallow(<SideBar show item={props.item} onClose={onClose} />);
-    wrapper.find(CloseButton).shallow().find('button').simulate('click');
+    wrapper
+      .find(CloseButton)
+      .shallow()
+      .find('button')
+      .simulate('click');
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/BaseNode.tsx
@@ -5,7 +5,7 @@ import { getImageForIconClass } from '../../../../../components/catalog/catalog-
 import { createFilterIdUrl } from '../../../shared/utils/svg-utils';
 import './BaseNode.scss';
 
-interface State {
+export interface State {
   hover?: boolean;
 }
 
@@ -14,7 +14,7 @@ export interface BaseNodeProps {
   y?: number;
   outerRadius: number;
   innerRadius?: number;
-  selected: boolean;
+  selected?: boolean;
   onSelect?: Function;
   icon?: string;
   label?: string;
@@ -24,6 +24,16 @@ export interface BaseNodeProps {
 
 const FILTER_ID = 'BaseNodeDropShadowFilterId';
 const FILTER_ID_HOVER = 'BaseNodeDropShadowFilterId--hover';
+
+const MAX_LABEL_LENGTH = 16;
+
+const truncateEnd = (text: string = ''): string => {
+  const length = text.length;
+  if (length <= MAX_LABEL_LENGTH) {
+    return text;
+  }
+  return `${text.substr(0, MAX_LABEL_LENGTH)}…`;
+};
 
 export default class BaseNode extends React.Component<BaseNodeProps, State> {
   state: State = {};
@@ -75,15 +85,17 @@ export default class BaseNode extends React.Component<BaseNodeProps, State> {
               getImageForIconClass(`icon-${icon}`) || getImageForIconClass('icon-openshift')
             }
           />
-          <text
-            className="odc-base-node__label"
-            textAnchor="middle"
-            y={outerRadius + 10}
-            x={0}
-            dy="0.6em"
-          >
-            {label}
-          </text>
+          {label != null && (
+            <text
+              className="odc-base-node__label"
+              textAnchor="middle"
+              y={outerRadius + 10}
+              x={0}
+              dy="0.6em"
+            >
+              {selected || hover ? label : truncateEnd(label)}
+            </text>
+          )}
           {selected && (
             <circle
               className="odc-base-node__selection"

--- a/frontend/public/extend/devconsole/components/topology/shapes/__tests__/BaseNode.spec.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/__tests__/BaseNode.spec.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import BaseNode, { BaseNodeProps, State } from '../BaseNode';
+import { mount, shallow } from 'enzyme';
+
+jest.mock('../../../../shared/components/svg/SvgDefs');
+jest.mock('../../../../../../components/catalog/catalog-item-icon', () => ({
+  getImageForIconClass: (path) => (path === 'icon-unknown' ? null : path),
+}));
+
+describe('BaseNode', () => {
+  it('should not render label if label is undefined', () => {
+    const wrapper = shallow(<BaseNode outerRadius={100} />);
+    expect(wrapper.find('text').exists()).toBeFalsy();
+  });
+
+  it('should not truncate labels <= 16 characters', () => {
+    const wrapper = shallow(<BaseNode outerRadius={100} label="1234567890abcdef" />);
+    expect(wrapper.find('text').text()).toBe('1234567890abcdef');
+  });
+
+  it('should truncate labels > 16 characters', () => {
+    const wrapper = shallow(<BaseNode outerRadius={100} label="1234567890abcdefgh" />);
+    expect(wrapper.find('text').text()).toBe('1234567890abcdef…');
+  });
+
+  it('should show long labels on hover', () => {
+    const wrapper = shallow<BaseNodeProps, State>(
+      <BaseNode outerRadius={100} label="1234567890abcdefgh" />,
+    );
+    wrapper.setState({ hover: true });
+    expect(wrapper.find('text').text()).toBe('1234567890abcdefgh');
+  });
+
+  it('should show different drop shadow on hover', () => {
+    const wrapper = shallow<BaseNodeProps, State>(<BaseNode outerRadius={100} />);
+    expect(
+      wrapper
+        .find('.odc-base-node__bg')
+        .first()
+        .props().filter,
+    ).toBe('url(blank#BaseNodeDropShadowFilterId)');
+
+    wrapper.setState({ hover: true });
+    expect(
+      wrapper
+        .find('.odc-base-node__bg')
+        .first()
+        .props().filter,
+    ).toBe('url(blank#BaseNodeDropShadowFilterId--hover)');
+  });
+
+  it('should show long labels when selected', () => {
+    const wrapper = shallow(<BaseNode outerRadius={100} selected label="1234567890abcdefgh" />);
+    expect(wrapper.find('text').text()).toBe('1234567890abcdefgh');
+  });
+
+  it('should render selection', () => {
+    const wrapper = shallow(<BaseNode outerRadius={100} selected />);
+    expect(wrapper.find('.odc-base-node__selection').exists()).toBeTruthy();
+  });
+
+  it('should render children and attachments', () => {
+    const wrapper = shallow(
+      <BaseNode outerRadius={100}>
+        <g id="test" />
+      </BaseNode>,
+    );
+    expect(wrapper.find('#test').exists()).toBeTruthy();
+  });
+
+  it('should render attachments', () => {
+    const wrapper = shallow(
+      <BaseNode
+        outerRadius={100}
+        attachments={[<g id="first" key="first" />, <g id="second" key="second" />]}
+      />,
+    );
+    expect(wrapper.find('#first').exists()).toBeTruthy();
+    expect(wrapper.find('#second').exists()).toBeTruthy();
+  });
+
+  it('should render icon', () => {
+    const wrapper = shallow(<BaseNode outerRadius={100} icon="testicon" />);
+    const imageWrapper = wrapper.find('image');
+    expect(imageWrapper.props().xlinkHref).toBe('icon-testicon');
+  });
+
+  it('should render fallback icon if icon cannot be found', () => {
+    const wrapper = shallow(<BaseNode outerRadius={100} icon="unknown" />);
+    const imageWrapper = wrapper.find('image');
+    expect(imageWrapper.props().xlinkHref).toBe('icon-openshift');
+  });
+
+  it('should handle selection', () => {
+    const onSelect = jest.fn();
+    const fakeEvent = { stopPropagation: jest.fn() };
+    const wrapper = mount(<BaseNode outerRadius={100} onSelect={onSelect} />);
+    wrapper.find('circle').simulate('click', fakeEvent);
+    expect(onSelect).toHaveBeenCalled();
+    expect(fakeEvent.stopPropagation).toHaveBeenCalled();
+  });
+
+  it('should ignore selectioon from attachments handle selection', () => {
+    const onSelect = jest.fn();
+    const fakeEvent = { stopPropagation: jest.fn() };
+    const wrapper = mount(
+      <BaseNode outerRadius={100} onSelect={onSelect} attachments={<g id="attachment" />} />,
+    );
+    wrapper.find('#attachment').simulate('click', fakeEvent);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/public/extend/devconsole/pages/Import.tsx
+++ b/frontend/public/extend/devconsole/pages/Import.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import { match as RMatch } from 'react-router';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/extend/devconsole/shared/components/svg/SvgDefs.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/SvgDefs.tsx
@@ -2,10 +2,10 @@
 import * as React from 'react';
 import SvgDefsContext, { SvgDefsContextProps } from './SvgDefsContext';
 
-type SvgDefsProps = {
+export interface SvgDefsProps {
   id: string;
   children: React.ReactNode;
-};
+}
 
 type SvgDefsSetterProps = SvgDefsContextProps & SvgDefsProps;
 

--- a/frontend/public/extend/devconsole/shared/components/svg/__mocks__/SvgDefs.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/__mocks__/SvgDefs.tsx
@@ -1,0 +1,8 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import { SvgDefsProps } from '../SvgDefs';
+
+// This mock simply renders the `defs` in place.
+const SvgDefsMock: React.FC<SvgDefsProps> = ({ id, children }) => <defs id={id}>{children}</defs>;
+
+export default SvgDefsMock;

--- a/frontend/public/extend/devconsole/shared/utils/__tests__/svg-utils.spec.ts
+++ b/frontend/public/extend/devconsole/shared/utils/__tests__/svg-utils.spec.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-unused-vars, no-undef */
+import { createFilterIdUrl } from '../svg-utils';
+
+const mockLocation = (location?: {
+hash?: string;
+port?: number;
+pathname?: string;
+search?: string;
+origin?: string;
+}) =>
+  ((window: any) => {
+    const windowLocation = JSON.stringify(window.location);
+    delete window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: JSON.parse(windowLocation),
+    });
+    if (location) {
+      Object.assign(window.location, location);
+    }
+  })(window);
+
+describe('svg-utils#createFilterIdUrl', () => {
+  it('should return absolute url based on pathname and search', () => {
+    mockLocation({
+      pathname: '/foo/bar',
+      search: '?key=value',
+    });
+    expect(createFilterIdUrl('testid')).toBe('url(/foo/bar?key=value#testid)');
+  });
+});


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-753

As per ux, the node labels on the topology should be truncated if > 16 characters. On hover, or selection, the full label is shown.

Added unit tests for `BaseNode`

![truncate-labels](https://user-images.githubusercontent.com/14068621/57255662-812e3980-7022-11e9-84f9-8a9c1e343b0a.gif)

