### PR TITLE
unit tests for svg utility components

### DIFF
--- a/frontend/public/extend/devconsole/shared/components/svg/SvgBoxedText.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/SvgBoxedText.tsx
@@ -3,19 +3,19 @@ import * as React from 'react';
 import SvgDropShadowFilter from './SvgDropShadowFilter';
 import { createFilterIdUrl } from '../../utils/svg-utils';
 
-interface State {
-  bb: SVGRect;
+export interface State {
+  bb: { width: number; height: number };
 }
 
-export type SvgBoxedTextProps = {
-  children: string;
-  className: string;
-  paddingX: number;
-  paddingY: number;
-  x: number;
-  y: number;
+export interface SvgBoxedTextProps {
+  children?: string;
+  className?: string;
+  paddingX?: number;
+  paddingY?: number;
+  x?: number;
+  y?: number;
   cornerRadius?: number;
-};
+}
 
 const FILTER_ID = 'SvgBoxedTextDropShadowFilterId';
 
@@ -27,31 +27,34 @@ export default class SvgBoxedText extends React.PureComponent<SvgBoxedTextProps,
     bb: null,
   };
 
-  textRef = React.createRef<SVGTextElement>();
+  private readonly textRef = React.createRef<SVGTextElement>();
 
   componentDidMount() {
     this.computeBoxSize();
   }
 
-  componentDidUpdate({ children }: SvgBoxedTextProps) {
-    if (this.props.children !== children) {
+  componentDidUpdate({ className, children }: SvgBoxedTextProps) {
+    if (this.props.children !== children || this.props.className !== className) {
       this.computeBoxSize();
     }
   }
 
   private computeBoxSize() {
-    this.setState({ bb: this.textRef.current.getBBox() });
+    const { current } = this.textRef;
+    if (current && current.getBBox) {
+      this.setState({ bb: current.getBBox() });
+    }
   }
 
   render() {
     const {
       children,
       className,
-      paddingX,
-      paddingY,
+      paddingX = 0,
+      paddingY = 0,
       cornerRadius = 4,
-      x,
-      y,
+      x = 0,
+      y = 0,
       ...other
     } = this.props;
     const { bb } = this.state;

--- a/frontend/public/extend/devconsole/shared/components/svg/SvgDefs.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/SvgDefs.tsx
@@ -7,9 +7,9 @@ export interface SvgDefsProps {
   children: React.ReactNode;
 }
 
-type SvgDefsSetterProps = SvgDefsContextProps & SvgDefsProps;
+export type SvgDefsSetterProps = SvgDefsContextProps & SvgDefsProps;
 
-class SvgDefsSetter extends React.Component<SvgDefsSetterProps> {
+export class SvgDefsSetter extends React.Component<SvgDefsSetterProps> {
   static contextType = SvgDefsContext;
 
   componentDidMount() {

--- a/frontend/public/extend/devconsole/shared/components/svg/SvgDefsProvider.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/SvgDefsProvider.tsx
@@ -9,12 +9,12 @@ interface DefsMap {
   };
 }
 
-interface DefsState {
+export interface DefsState {
   defs?: DefsMap;
 }
 
-class Defs extends React.PureComponent<{}, DefsState> {
-  state = {
+export class Defs extends React.PureComponent<{}, DefsState> {
+  state: DefsState = {
     defs: null,
   };
 
@@ -46,9 +46,9 @@ export interface SvgDefsProviderProps {
  * such as filters, are eliminated.
  */
 class SvgDefsProvider extends React.Component<SvgDefsProviderProps> {
-  private defsRef = React.createRef<Defs>();
+  private readonly defsRef = React.createRef<Defs>();
 
-  private defs: DefsMap = {};
+  private readonly defs: DefsMap = {};
 
   private contextValue: SvgDefsContextProps = {
     addDef: (id, node) => {

--- a/frontend/public/extend/devconsole/shared/components/svg/SvgDropShadowFilter.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/SvgDropShadowFilter.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import SvgDefs from '../../../shared/components/svg/SvgDefs';
 
-interface SvgDropShadowFilterProps {
+export interface SvgDropShadowFilterProps {
   /* The unique ID that identifies the filter.
      It is also used to uniquely identify the def entry to prevent duplicates. */
   id: string;

--- a/frontend/public/extend/devconsole/shared/components/svg/__tests__/SvgBoxedText.spec.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/__tests__/SvgBoxedText.spec.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import SvgBoxedText, { SvgBoxedTextProps, State } from '../SvgBoxedText';
+
+describe('SvgBoxedText', () => {
+  it('should initially render without a backdrop', () => {
+    const wrapper = shallow(<SvgBoxedText />);
+    expect(wrapper.find('rect').exists()).toBeFalsy();
+  });
+
+  it('should render backdrop around text', () => {
+    const wrapper = shallow(<SvgBoxedText />);
+    wrapper.setState({ bb: { width: 20, height: 10 } });
+    expect(wrapper.find('rect').exists()).toBeTruthy();
+  });
+
+  it('should position backdrop around text', () => {
+    const wrapper = shallow<SvgBoxedTextProps, State>(
+      <SvgBoxedText cornerRadius={5} x={100} y={200} paddingX={10} paddingY={5} />,
+    );
+    wrapper.setState({ bb: { width: 50, height: 20 } });
+    const rectWrapper = wrapper.find('rect').first();
+    const { filter, ...otherProps } = rectWrapper.props();
+    expect(otherProps).toEqual({
+      rx: 5,
+      ry: 5,
+      x: 65,
+      y: 185,
+      width: 70,
+      height: 30,
+    });
+  });
+});

--- a/frontend/public/extend/devconsole/shared/components/svg/__tests__/SvgDefs.spec.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/__tests__/SvgDefs.spec.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { SvgDefsSetter, SvgDefsSetterProps } from '../SvgDefs';
+
+// FIXME context api enzyme error: Enzyme Internal Error: unknown node with tag 13
+// need to update enzyme and enzyme-adapter-react-16
+// describe('SvgDefs', () => {
+//   it('should get #addDef and #removeDef from context', () => {
+//     const contextProps: SvgDefsContextProps = {
+//       addDef: jest.fn(),
+//       removeDef: jest.fn(),
+//     };
+//     const props: SvgDefsProps = {
+//       id: 'foo',
+//       children: <span />,
+//     };
+//     const wrapper = mount(
+//       <SvgDefsContext.Provider value={contextProps}>
+//         <SvgDefs {...props} />
+//       </SvgDefsContext.Provider>,
+//     );
+//     const innerWrapper = wrapper.find(SvgDefsSetter).first();
+//     expect(innerWrapper.props()).toEqual({
+//       ...contextProps,
+//       ...props,
+//     });
+//   });
+// });
+
+describe('SvgDefsSetter', () => {
+  it('should callback #addDef asnd #removeDef on update', () => {
+    const props: SvgDefsSetterProps = {
+      id: 'foo',
+      addDef: jest.fn(),
+      removeDef: jest.fn(),
+      children: <span />,
+    };
+
+    const wrapper = shallow<SvgDefsSetterProps>(<SvgDefsSetter {...props} />);
+    expect(props.addDef).toHaveBeenCalledWith(props.id, props.children);
+
+    // test update
+    const newChild = <span />;
+    wrapper.setProps({ children: newChild });
+    expect(props.addDef).toHaveBeenCalledTimes(2);
+    expect(props.addDef).toHaveBeenLastCalledWith(props.id, newChild);
+
+    // test unmount
+    wrapper.unmount();
+    expect(props.removeDef).toHaveBeenCalledTimes(1);
+    expect(props.removeDef).toHaveBeenLastCalledWith(props.id);
+  });
+});

--- a/frontend/public/extend/devconsole/shared/components/svg/__tests__/SvgDefsProvider.spec.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/__tests__/SvgDefsProvider.spec.tsx
@@ -32,6 +32,4 @@ describe('Defs', () => {
         .props().children,
     ).toBe(state.defs.second.node);
   });
-
-  it('should render defs');
 });

--- a/frontend/public/extend/devconsole/shared/components/svg/__tests__/SvgDefsProvider.spec.tsx
+++ b/frontend/public/extend/devconsole/shared/components/svg/__tests__/SvgDefsProvider.spec.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Defs, DefsState } from '../SvgDefsProvider';
+
+describe('Defs', () => {
+  it('should render initially empty', () => {
+    const wrapper = shallow(<Defs />);
+    expect(wrapper.find('defs').exists()).toBeFalsy();
+  });
+
+  it('should render defs', () => {
+    const wrapper = shallow<{}, DefsState>(<Defs />);
+    const state: DefsState = {
+      defs: {
+        first: { count: 0, node: <span /> },
+        second: { count: 0, node: <span /> },
+      },
+    };
+    wrapper.setState(state);
+    const defsWrapper = wrapper.find('defs');
+    expect(
+      defsWrapper
+        .childAt(0)
+        .first()
+        .props().children,
+    ).toBe(state.defs.first.node);
+    expect(
+      defsWrapper
+        .childAt(1)
+        .first()
+        .props().children,
+    ).toBe(state.defs.second.node);
+  });
+
+  it('should render defs');
+});


### PR DESCRIPTION
Adds some unit tests to the svg utility components.

Could not properly test components relying on newer react context api. From investigation it looks like i need to upgrade `enzyme` and / or the `enzyme-adapter-react-16`. Will look into this further once we  update with latest from console master or move to console repo.