### PR TITLE
revert change to editUrl left in place during testing

### DIFF
--- a/frontend/public/extend/devconsole/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/WorkloadNode.tsx
@@ -31,7 +31,7 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
       selected={selected}
       onSelect={onSelect}
       attachments={[
-        workload.data.url && (
+        workload.data.editUrl && (
           <Decorator
             key="edit"
             x={radius - decoratorRadius * 0.7}


### PR DESCRIPTION
Revert change to `editUrl` which was mistakenly added in previous commit.