### PR TITLE
WIP Proxy to devconsole api

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -274,6 +274,15 @@ func main() {
 				Endpoint:        &url.URL{Scheme: "https", Host: openshiftAlertManagerHost, Path: "/api"},
 			}
 		}
+
+		srv.DevConsoleAppServiceProxyConfig = &proxy.Config{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: *fK8sModeOffClusterSkipVerifyTLS,
+			},
+			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
+			Endpoint:        &url.URL{Scheme: "http", Host: openshiftDevConsoleAppServiceHost, Path: ""},
+		}
+
 	case "off-cluster":
 		k8sEndpoint = validateFlagIsURL("k8s-mode-off-cluster-endpoint", *fK8sModeOffClusterEndpoint)
 
@@ -284,6 +293,7 @@ func main() {
 			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 			Endpoint:        k8sEndpoint,
 		}
+		// TODO: remove this later
 		srv.DevConsoleAppServiceProxyConfig = &proxy.Config{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: *fK8sModeOffClusterSkipVerifyTLS,

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -39,7 +39,7 @@ const (
 
 	// Well-known location of DevConsole App Service for OpenShift. This is only accessible in-cluster after
 	// the developer perspective is enabled using the operator.
-	openshiftDevConsoleAppServiceHost = "devconsole.openshift-operators.csv:8080" // TODO:use a different namespace?
+	openshiftDevConsoleAppServiceHost = "devconsole.openshift-operators.svc:8080" // TODO:use a different namespace?
 )
 
 func main() {

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -36,6 +36,10 @@ const (
 
 	// Well-known location of Alert Manager service for OpenShift. This is only accessible in-cluster.
 	openshiftAlertManagerHost = "alertmanager-main.openshift-monitoring.svc:9094"
+
+	// Well-known location of DevConsole App Service for OpenShift. This is only accessible in-cluster after
+	// the developer perspective is enabled using the operator.
+	openshiftDevConsoleAppServiceHost = "devconsole.openshift-operators.csv:8080" // TODO:use a different namespace?
 )
 
 func main() {
@@ -270,7 +274,6 @@ func main() {
 				Endpoint:        &url.URL{Scheme: "https", Host: openshiftAlertManagerHost, Path: "/api"},
 			}
 		}
-
 	case "off-cluster":
 		k8sEndpoint = validateFlagIsURL("k8s-mode-off-cluster-endpoint", *fK8sModeOffClusterEndpoint)
 
@@ -280,6 +283,13 @@ func main() {
 			},
 			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 			Endpoint:        k8sEndpoint,
+		}
+		srv.DevConsoleAppServiceProxyConfig = &proxy.Config{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: *fK8sModeOffClusterSkipVerifyTLS,
+			},
+			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
+			Endpoint:        &url.URL{Scheme: "http", Host: openshiftDevConsoleAppServiceHost, Path: ""},
 		}
 	default:
 		flagFatalf("k8s-mode", "must be one of: in-cluster, off-cluster")

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -283,15 +283,6 @@ func main() {
 			Endpoint:        &url.URL{Scheme: "http", Host: openshiftDevConsoleAppServiceHost, Path: ""},
 		}
 
-		// TODO: remove this later
-		srv.DevConsoleAppServiceProxyConfig = &proxy.Config{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: *fK8sModeOffClusterSkipVerifyTLS,
-			},
-			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
-			Endpoint:        &url.URL{Scheme: "http", Host: openshiftDevConsoleAppServiceHost, Path: ""},
-		}
-
 	case "off-cluster":
 		k8sEndpoint = validateFlagIsURL("k8s-mode-off-cluster-endpoint", *fK8sModeOffClusterEndpoint)
 

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -283,6 +283,15 @@ func main() {
 			Endpoint:        &url.URL{Scheme: "http", Host: openshiftDevConsoleAppServiceHost, Path: ""},
 		}
 
+		// TODO: remove this later
+		srv.DevConsoleAppServiceProxyConfig = &proxy.Config{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: *fK8sModeOffClusterSkipVerifyTLS,
+			},
+			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
+			Endpoint:        &url.URL{Scheme: "http", Host: openshiftDevConsoleAppServiceHost, Path: ""},
+		}
+
 	case "off-cluster":
 		k8sEndpoint = validateFlagIsURL("k8s-mode-off-cluster-endpoint", *fK8sModeOffClusterEndpoint)
 
@@ -293,14 +302,7 @@ func main() {
 			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 			Endpoint:        k8sEndpoint,
 		}
-		// TODO: remove this later
-		srv.DevConsoleAppServiceProxyConfig = &proxy.Config{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: *fK8sModeOffClusterSkipVerifyTLS,
-			},
-			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
-			Endpoint:        &url.URL{Scheme: "http", Host: openshiftDevConsoleAppServiceHost, Path: ""},
-		}
+
 	default:
 		flagFatalf("k8s-mode", "must be one of: in-cluster, off-cluster")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -40,25 +40,25 @@ var (
 )
 
 type jsGlobals struct {
-	ConsoleVersion           string `json:"consoleVersion"`
-	AuthDisabled             bool   `json:"authDisabled"`
-	KubectlClientID          string `json:"kubectlClientID"`
-	BasePath                 string `json:"basePath"`
-	LoginURL                 string `json:"loginURL"`
-	LoginSuccessURL          string `json:"loginSuccessURL"`
-	LoginErrorURL            string `json:"loginErrorURL"`
-	LogoutURL                string `json:"logoutURL"`
-	LogoutRedirect           string `json:"logoutRedirect"`
-	KubeAdminLogoutURL       string `json:"kubeAdminLogoutURL"`
-	KubeAPIServerURL         string `json:"kubeAPIServerURL"`
-	PrometheusBaseURL        string `json:"prometheusBaseURL"`
-	PrometheusTenancyBaseURL string `json:"prometheusTenancyBaseURL"`
-	AlertManagerBaseURL      string `json:"alertManagerBaseURL"`
-	Branding                 string `json:"branding"`
-	DocumentationBaseURL     string `json:"documentationBaseURL"`
-	GoogleTagManagerID       string `json:"googleTagManagerID"`
-	LoadTestFactor           int    `json:"loadTestFactor"`
-	AppServiceBaseURL        string `json:"appServiceBaseURL"`
+	ConsoleVersion              string `json:"consoleVersion"`
+	AuthDisabled                bool   `json:"authDisabled"`
+	KubectlClientID             string `json:"kubectlClientID"`
+	BasePath                    string `json:"basePath"`
+	LoginURL                    string `json:"loginURL"`
+	LoginSuccessURL             string `json:"loginSuccessURL"`
+	LoginErrorURL               string `json:"loginErrorURL"`
+	LogoutURL                   string `json:"logoutURL"`
+	LogoutRedirect              string `json:"logoutRedirect"`
+	KubeAdminLogoutURL          string `json:"kubeAdminLogoutURL"`
+	KubeAPIServerURL            string `json:"kubeAPIServerURL"`
+	PrometheusBaseURL           string `json:"prometheusBaseURL"`
+	PrometheusTenancyBaseURL    string `json:"prometheusTenancyBaseURL"`
+	AlertManagerBaseURL         string `json:"alertManagerBaseURL"`
+	Branding                    string `json:"branding"`
+	DocumentationBaseURL        string `json:"documentationBaseURL"`
+	GoogleTagManagerID          string `json:"googleTagManagerID"`
+	LoadTestFactor              int    `json:"loadTestFactor"`
+	DevConsoleAppServiceBaseURL string `json:"devConsoleAppService"`
 }
 
 type Server struct {
@@ -222,17 +222,17 @@ func (s *Server) HTTPHandler() http.Handler {
 	}
 
 	if s.devConsoleAppServiceProxyEnabled() {
-		appServiceProxyAPIPath := devConsoleAppServiceProxyEndpoint
-		appServiceProxy := proxy.NewProxy(s.DevConsoleAppServiceProxyConfig)
+		devConsoleAppServiceProxyAPIPath := devConsoleAppServiceProxyEndpoint
+		devConsoleAppServiceProxy := proxy.NewProxy(s.DevConsoleAppServiceProxyConfig)
 
-		handle(appServiceProxyAPIPath, http.StripPrefix(
-			proxy.SingleJoiningSlash(s.BaseURL.Path, appServiceProxyAPIPath),
+		handle(devConsoleAppServiceProxyAPIPath, http.StripPrefix(
+			proxy.SingleJoiningSlash(s.BaseURL.Path, devConsoleAppServiceProxyAPIPath),
 			authHandlerWithUser(func(user *auth.User, w http.ResponseWriter, r *http.Request) {
 				r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.Token))
-				appServiceProxy.ServeHTTP(w, r)
+				devConsoleAppServiceProxy.ServeHTTP(w, r)
 			})),
 		)
-		fmt.Println("enabling proxy for " + proxy.SingleJoiningSlash(s.BaseURL.Path, appServiceProxyAPIPath))
+		fmt.Println("enabling proxy for " + proxy.SingleJoiningSlash(s.BaseURL.Path, devConsoleAppServiceProxyAPIPath))
 	}
 
 	handle("/api/tectonic/version", authHandler(s.versionHandler))
@@ -294,8 +294,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.devConsoleAppServiceProxyEnabled() {
-		jsg.AppServiceBaseURL = proxy.SingleJoiningSlash(s.BaseURL.Path, devConsoleAppServiceProxyEndpoint)
-		fmt.Println(jsg.AppServiceBaseURL)
+		jsg.DevConsoleAppServiceBaseURL = proxy.SingleJoiningSlash(s.BaseURL.Path, devConsoleAppServiceProxyEndpoint)
 	}
 
 	if !s.authDisabled() {


### PR DESCRIPTION
Assuming the devconsole API service , which would _house_ the topology backend, is deployed by the operator https://github.com/redhat-developer/devconsole-operator/pull/195/files , this change exposes a console API `/api/devconsole/` which proxies to the REST service, with authorization headers.

The authorization header contains the user's openshift token.