### PR TITLE
Application switcher

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -327,8 +327,8 @@ class NamespaceBarDropdowns_ extends React.Component {
           menuClassName="co-add-actions-selector__menu dropdown-menu--right"
           buttonClassName="btn-link" /> :
         <ApplicationSwitcher
-          activeNamespace={activeNamespace}
-          activeApplication={activeApplication}
+          namespace={activeNamespace}
+          application={activeApplication}
           allApplicationsKey={ALL_APPLICATIONS_KEY}
           allNamespacesKey={ALL_NAMESPACES_KEY}
           selectedKey={activeApplication || ALL_APPLICATIONS_KEY}

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -18,7 +18,7 @@ import { FLAGS, featureReducerName, flagPending, setFlag, connectToFlags } from 
 import { openshiftHelpBase } from './utils/documentation';
 import { createProjectMessageStateToProps } from '../ui/ui-reducers';
 import PerspectiveLink from '../extend/devconsole/shared/components/PerspectiveLink';
-import { getActivePerspective } from '../ui/ui-selectors';
+import { getActivePerspective, getActiveApplication } from '../ui/ui-selectors';
 import { pathWithPerspective } from './utils/perspective';
 import ApplicationSwitcher from '../extend/devconsole/components/application-switcher/ApplicationSwitcher';
 
@@ -245,7 +245,7 @@ const defaultBookmarks = {};
 const namespaceBarDropdownStateToProps = state => {
   return {
     activeNamespace: state.UI.get('activeNamespace'),
-    activeApplication: state.UI.get('activeApplication'),
+    activeApplication: getActiveApplication(state),
     activePerspective: getActivePerspective(state),
     canListNS: state[featureReducerName].get(FLAGS.CAN_LIST_NS),
   };

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -13,13 +13,14 @@ import { ActionsMenu, Kebab, Dropdown, Firehose, LabelList, LoadingInline, navFa
 import { createNamespaceModal, createProjectModal, deleteNamespaceModal, configureNamespacePullSecretModal } from './modals';
 import { RoleBindingsPage } from './RBAC';
 import { Bar, Line, requirePrometheus } from './graphs';
-import { NAMESPACE_LOCAL_STORAGE_KEY, ALL_NAMESPACES_KEY } from '../const';
+import { NAMESPACE_LOCAL_STORAGE_KEY, ALL_NAMESPACES_KEY, ALL_APPLICATIONS_KEY, APPLICATION_LOCAL_STORAGE_KEY } from '../const';
 import { FLAGS, featureReducerName, flagPending, setFlag, connectToFlags } from '../features';
 import { openshiftHelpBase } from './utils/documentation';
 import { createProjectMessageStateToProps } from '../ui/ui-reducers';
 import PerspectiveLink from '../extend/devconsole/shared/components/PerspectiveLink';
 import { getActivePerspective } from '../ui/ui-selectors';
 import { pathWithPerspective } from './utils/perspective';
+import ApplicationSwitcher from '../extend/devconsole/components/application-switcher/ApplicationSwitcher';
 
 const getModel = useProjects => useProjects ? ProjectModel : NamespaceModel;
 const getDisplayName = obj => _.get(obj, ['metadata', 'annotations', 'openshift.io/display-name']);
@@ -244,6 +245,7 @@ const defaultBookmarks = {};
 const namespaceBarDropdownStateToProps = state => {
   return {
     activeNamespace: state.UI.get('activeNamespace'),
+    activeApplication: state.UI.get('activeApplication'),
     activePerspective: getActivePerspective(state),
     canListNS: state[featureReducerName].get(FLAGS.CAN_LIST_NS),
   };
@@ -260,7 +262,7 @@ class NamespaceBarDropdowns_ extends React.Component {
   }
 
   render() {
-    const { activeNamespace, activePerspective, dispatch, canListNS, useProjects } = this.props;
+    const { activeNamespace, activeApplication, activePerspective, dispatch, canListNS, useProjects } = this.props;
     if (flagPending(canListNS)) {
       return null;
     }
@@ -284,6 +286,8 @@ class NamespaceBarDropdowns_ extends React.Component {
     }
 
     const onChange = newNamespace => dispatch(UIActions.setActiveNamespace(newNamespace));
+
+    const onApplicationChange = (newApplication) => dispatch(UIActions.setActiveApplication(newApplication));
 
     const addActions = [
       {
@@ -316,13 +320,20 @@ class NamespaceBarDropdowns_ extends React.Component {
         defaultBookmarks={defaultBookmarks}
         storageKey={NAMESPACE_LOCAL_STORAGE_KEY}
         shortCut="n" />
-      {activePerspective !== 'dev' &&
+      {activePerspective !== 'dev' ?
         <ActionsMenu
           actions={addActions}
           title={<React.Fragment><span className="fa fa-plus-circle co-add-actions-selector__icon" aria-hidden="true"></span> Add</React.Fragment>}
           menuClassName="co-add-actions-selector__menu dropdown-menu--right"
-          buttonClassName="btn-link"
-        />
+          buttonClassName="btn-link" /> :
+        <ApplicationSwitcher
+          activeNamespace={activeNamespace}
+          activeApplication={activeApplication}
+          allApplicationsKey={ALL_APPLICATIONS_KEY}
+          allNamespacesKey={ALL_NAMESPACES_KEY}
+          selectedKey={activeApplication || ALL_APPLICATIONS_KEY}
+          onChange={onApplicationChange}
+          storageKey={APPLICATION_LOCAL_STORAGE_KEY} />
       }
     </div>;
   }

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -13,7 +13,7 @@ import { ActionsMenu, Kebab, Dropdown, Firehose, LabelList, LoadingInline, navFa
 import { createNamespaceModal, createProjectModal, deleteNamespaceModal, configureNamespacePullSecretModal } from './modals';
 import { RoleBindingsPage } from './RBAC';
 import { Bar, Line, requirePrometheus } from './graphs';
-import { NAMESPACE_LOCAL_STORAGE_KEY, ALL_NAMESPACES_KEY, ALL_APPLICATIONS_KEY, APPLICATION_LOCAL_STORAGE_KEY } from '../const';
+import { NAMESPACE_LOCAL_STORAGE_KEY, ALL_NAMESPACES_KEY } from '../const';
 import { FLAGS, featureReducerName, flagPending, setFlag, connectToFlags } from '../features';
 import { openshiftHelpBase } from './utils/documentation';
 import { createProjectMessageStateToProps } from '../ui/ui-reducers';
@@ -329,11 +329,7 @@ class NamespaceBarDropdowns_ extends React.Component {
         <ApplicationSwitcher
           namespace={activeNamespace}
           application={activeApplication}
-          allApplicationsKey={ALL_APPLICATIONS_KEY}
-          allNamespacesKey={ALL_NAMESPACES_KEY}
-          selectedKey={activeApplication || ALL_APPLICATIONS_KEY}
-          onChange={onApplicationChange}
-          storageKey={APPLICATION_LOCAL_STORAGE_KEY} />
+          onChange={onApplicationChange} />
       }
     </div>;
   }

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -298,7 +298,7 @@ export class Dropdown extends DropdownMixin {
 
   render() {
     const {active, autocompleteText, selectedKey, items, title, bookmarks, keyboardHoverKey, favoriteKey} = this.state;
-    const {autocompleteFilter, autocompletePlaceholder, actionItem, className, buttonClassName, menuClassName, storageKey, canFavorite, dropDownClassName, titlePrefix, describedBy} = this.props;
+    const {autocompleteFilter, autocompletePlaceholder, actionItem, className, buttonClassName, menuClassName, storageKey, canFavorite, dropDownClassName, titlePrefix, describedBy, disabled} = this.props;
 
     const spacerBefore = this.props.spacerBefore || new Set();
     const headerBefore = this.props.headerBefore || {};
@@ -350,7 +350,7 @@ export class Dropdown extends DropdownMixin {
 
     return <div className={classNames(className)} ref={this.dropdownElement} style={this.props.style}>
       <div className={classNames('dropdown', dropDownClassName)}>
-        <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn-dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id} aria-describedby={describedBy} disabled={this.props.disabled} >
+        <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn-dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id} aria-describedby={describedBy} disabled={disabled} >
           <div className="btn-dropdown__content-wrap">
             <span className="btn-dropdown__item">
               {titlePrefix && <span className="btn-link__titlePrefix">{titlePrefix}: </span>}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -149,10 +149,10 @@ export class Dropdown extends DropdownMixin {
 
     this.state.items = Object.assign({}, bookmarks, props.items);
 
+    const defaultTitle = React.isValidElement(props.title) ? props.title : <span className="btn-dropdown__item--placeholder">{props.title}</span>;
     this.state.title = props.noSelection
       ? props.title
-      : _.get(props.items, props.selectedKey, <span className="btn-dropdown__item--placeholder">{props.title}</span>);
-
+      : _.get(props.items, props.selectedKey, defaultTitle);
     this.onKeyDown = e => this.onKeyDown_(e);
     this.changeTextFilter = e => this.applyTextFilter_(e.target.value, this.props.items);
     const { shortCut } = this.props;
@@ -299,7 +299,6 @@ export class Dropdown extends DropdownMixin {
   render() {
     const {active, autocompleteText, selectedKey, items, title, bookmarks, keyboardHoverKey, favoriteKey} = this.state;
     const {autocompleteFilter, autocompletePlaceholder, actionItem, className, buttonClassName, menuClassName, storageKey, canFavorite, dropDownClassName, titlePrefix, describedBy, disabled} = this.props;
-
     const spacerBefore = this.props.spacerBefore || new Set();
     const headerBefore = this.props.headerBefore || {};
     const rows = [];

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -62,6 +62,11 @@ export class DropdownMixin extends React.PureComponent {
 
   toggle(e) {
     e.preventDefault();
+
+    if (this.props.disabled) {
+      return;
+    }
+
     if (this.state.active) {
       this.hide(e);
     } else {
@@ -299,8 +304,10 @@ export class Dropdown extends DropdownMixin {
     const headerBefore = this.props.headerBefore || {};
     const rows = [];
     const bookMarkRows = [];
-
     const addItem = (key, content) => {
+      if (!this.props.items[key]) {
+        return;
+      }
       const selected = (key === selectedKey) && !this.props.noSelection;
       const hover = key === keyboardHoverKey;
       const klass = classNames({'active': selected});
@@ -343,7 +350,7 @@ export class Dropdown extends DropdownMixin {
 
     return <div className={classNames(className)} ref={this.dropdownElement} style={this.props.style}>
       <div className={classNames('dropdown', dropDownClassName)}>
-        <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn-dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id} aria-describedby={describedBy} >
+        <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn-dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id} aria-describedby={describedBy} disabled={this.props.disabled} >
           <div className="btn-dropdown__content-wrap">
             <span className="btn-dropdown__item">
               {titlePrefix && <span className="btn-link__titlePrefix">{titlePrefix}: </span>}
@@ -401,6 +408,7 @@ Dropdown.propTypes = {
   spacerBefore: PropTypes.instanceOf(Set),
   textFilter: PropTypes.string,
   title: PropTypes.node,
+  disabled: PropTypes.bool,
 };
 
 export const ActionsMenu = (props) => {

--- a/frontend/public/const.js
+++ b/frontend/public/const.js
@@ -18,7 +18,7 @@ export const EVENTS = {
 // Use a key for the "all" namespaces option that would be an invalid namespace name to avoid a potential clash
 export const ALL_NAMESPACES_KEY = '#ALL_NS#';
 
-// Use a key for the "all" namespaces option that would be an invalid namespace name to avoid a potential clash
+// Use a key for the "all" applications option that would be an invalid application name to avoid a potential clash
 export const ALL_APPLICATIONS_KEY = '#ALL_APPS#';
 
 // Prefix our localStorage items to avoid conflicts if another app ever runs on the same domain.

--- a/frontend/public/const.js
+++ b/frontend/public/const.js
@@ -28,7 +28,6 @@ const STORAGE_PREFIX = 'bridge';
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
 export const APPLICATION_LOCAL_STORAGE_KEY = 'dropdown-storage-applications';
 export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
-export const LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-application-name`;
 export const LAST_PERSPECTIVE_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-perspective`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;

--- a/frontend/public/const.js
+++ b/frontend/public/const.js
@@ -18,12 +18,17 @@ export const EVENTS = {
 // Use a key for the "all" namespaces option that would be an invalid namespace name to avoid a potential clash
 export const ALL_NAMESPACES_KEY = '#ALL_NS#';
 
+// Use a key for the "all" namespaces option that would be an invalid namespace name to avoid a potential clash
+export const ALL_APPLICATIONS_KEY = '#ALL_APPS#';
+
 // Prefix our localStorage items to avoid conflicts if another app ever runs on the same domain.
 const STORAGE_PREFIX = 'bridge';
 
 // This localStorage key predates the storage prefix.
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
+export const APPLICATION_LOCAL_STORAGE_KEY = 'dropdown-storage-applications';
 export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
+export const LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-application-name`;
 export const LAST_PERSPECTIVE_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-perspective`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;

--- a/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
+++ b/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 import AppDropdown from '../../shared/components/dropdown/AppDropdown';
 
 interface ApplicationSwitcherProps {
-  activeNamespace: string;
-  activeApplication: string;
+  namespace: string;
+  application: string;
   selectedKey: string;
   allApplicationsKey: string;
   allNamespacesKey: string;
@@ -20,13 +20,15 @@ const ApplicationSwitcher: React.FC<ApplicationSwitcherProps> = (props) => {
   const allApplicationsTitle = 'all applications';
 
   let disabled: boolean = false;
-  if (props.activeNamespace === props.allNamespacesKey) {
+  if (props.namespace === props.allNamespacesKey) {
     disabled = true;
   }
 
-  let title: string = props.activeApplication;
-  if (title === props.allApplicationsKey) {
+  let title: string = props.application;
+  if (title === props.allApplicationsKey && !disabled) {
     title = allApplicationsTitle;
+  } else if (disabled) {
+    title = 'No applications';
   }
 
   return (
@@ -34,7 +36,7 @@ const ApplicationSwitcher: React.FC<ApplicationSwitcherProps> = (props) => {
       className="co-namespace-selector"
       menuClassName="co-namespace-selector__menu dropdown-menu--right"
       buttonClassName="btn-link"
-      namespace={props.activeNamespace}
+      namespace={props.namespace}
       title={title && <span className="btn-link__title">{title}</span>}
       titlePrefix="Application"
       allApplicationsKey={props.allApplicationsKey}

--- a/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
+++ b/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+
+import AppDropdown from '../../shared/components/dropdown/AppDropdown';
+
+interface ApplicationSwitcherProps {
+  activeNamespace: string;
+  activeApplication: string;
+  selectedKey: string;
+  allApplicationsKey: string;
+  allNamespacesKey: string;
+  storageKey: string;
+  onChange: (name: string) => void;
+}
+
+const ApplicationSwitcher: React.FC<ApplicationSwitcherProps> = (props) => {
+  const onApplicationChange = (newApplication, key) => {
+    key === props.allApplicationsKey ? props.onChange(key) : props.onChange(newApplication);
+  };
+  const allApplicationsTitle = 'all applications';
+
+  let disabled: boolean = false;
+  if (props.activeNamespace === props.allNamespacesKey) {
+    disabled = true;
+  }
+
+  let title: string = props.activeApplication;
+  if (title === props.allApplicationsKey) {
+    title = allApplicationsTitle;
+  }
+
+  return (
+    <AppDropdown
+      className="co-namespace-selector"
+      menuClassName="co-namespace-selector__menu dropdown-menu--right"
+      buttonClassName="btn-link"
+      namespace={props.activeNamespace}
+      title={title && <span className="btn-link__title">{title}</span>}
+      titlePrefix="Application"
+      allApplicationsKey={props.allApplicationsKey}
+      selectedKey={props.selectedKey}
+      onChange={onApplicationChange}
+      storageKey={props.storageKey}
+      canFavorite
+      disabled={disabled}
+    />
+  );
+};
+
+export default ApplicationSwitcher;

--- a/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
+++ b/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
@@ -2,30 +2,35 @@
 import * as React from 'react';
 
 import AppDropdown from '../../shared/components/dropdown/AppDropdown';
+import {
+  ALL_NAMESPACES_KEY,
+  ALL_APPLICATIONS_KEY,
+  APPLICATION_LOCAL_STORAGE_KEY,
+} from '../../../../../public/const';
 
 interface ApplicationSwitcherProps {
   namespace: string;
   application: string;
-  selectedKey: string;
-  allApplicationsKey: string;
-  allNamespacesKey: string;
-  storageKey: string;
   onChange: (name: string) => void;
 }
 
-const ApplicationSwitcher: React.FC<ApplicationSwitcherProps> = (props) => {
+const ApplicationSwitcher: React.FC<ApplicationSwitcherProps> = ({
+  namespace,
+  application,
+  onChange,
+}) => {
   const onApplicationChange = (newApplication, key) => {
-    key === props.allApplicationsKey ? props.onChange(key) : props.onChange(newApplication);
+    key === ALL_APPLICATIONS_KEY ? onChange(key) : onChange(newApplication);
   };
   const allApplicationsTitle = 'all applications';
 
   let disabled: boolean = false;
-  if (props.namespace === props.allNamespacesKey) {
+  if (namespace === ALL_NAMESPACES_KEY) {
     disabled = true;
   }
 
-  let title: string = props.application;
-  if (title === props.allApplicationsKey && !disabled) {
+  let title: string = application;
+  if (title === ALL_APPLICATIONS_KEY && !disabled) {
     title = allApplicationsTitle;
   } else if (disabled) {
     title = 'No applications';
@@ -36,16 +41,16 @@ const ApplicationSwitcher: React.FC<ApplicationSwitcherProps> = (props) => {
       className="co-namespace-selector"
       menuClassName="co-namespace-selector__menu dropdown-menu--right"
       buttonClassName="btn-link"
-      namespace={props.namespace}
+      namespace={namespace}
       title={title && <span className="btn-link__title">{title}</span>}
       titlePrefix="Application"
       allSelectorItem={{
-        allSelectorKey: props.allApplicationsKey,
+        allSelectorKey: ALL_APPLICATIONS_KEY,
         allSelectorTitle: allApplicationsTitle,
       }}
-      selectedKey={props.selectedKey}
+      selectedKey={application || ALL_APPLICATIONS_KEY}
       onChange={onApplicationChange}
-      storageKey={props.storageKey}
+      storageKey={APPLICATION_LOCAL_STORAGE_KEY}
       disabled={disabled}
     />
   );

--- a/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
+++ b/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
@@ -46,7 +46,6 @@ const ApplicationSwitcher: React.FC<ApplicationSwitcherProps> = (props) => {
       selectedKey={props.selectedKey}
       onChange={onApplicationChange}
       storageKey={props.storageKey}
-      canFavorite
       disabled={disabled}
     />
   );

--- a/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
+++ b/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
@@ -39,7 +39,10 @@ const ApplicationSwitcher: React.FC<ApplicationSwitcherProps> = (props) => {
       namespace={props.namespace}
       title={title && <span className="btn-link__title">{title}</span>}
       titlePrefix="Application"
-      allApplicationsKey={props.allApplicationsKey}
+      allSelectorItem={{
+        allSelectorKey: props.allApplicationsKey,
+        allSelectorTitle: allApplicationsTitle,
+      }}
       selectedKey={props.selectedKey}
       onChange={onApplicationChange}
       storageKey={props.storageKey}

--- a/frontend/public/extend/devconsole/shared/components/dropdown/AppDropdown.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/AppDropdown.tsx
@@ -5,6 +5,15 @@ import LabelDropdown from './LabelDropdown';
 import { Firehose } from '../../../../../components/utils';
 
 interface AppDropdownProps {
+  className?: string;
+  menuClassName?: string;
+  buttonClassName?: string;
+  title?: React.ReactNode;
+  titlePrefix?: string;
+  allApplicationsKey?: string;
+  storageKey?: string;
+  canFavorite?: boolean;
+  disabled?: boolean;
   namespace?: string;
   actionItem?: {
     actionTitle: string;

--- a/frontend/public/extend/devconsole/shared/components/dropdown/AppDropdown.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/AppDropdown.tsx
@@ -13,7 +13,6 @@ interface AppDropdownProps {
   titlePrefix?: string;
   allApplicationsKey?: string;
   storageKey?: string;
-  canFavorite?: boolean;
   disabled?: boolean;
   allSelectorItem?: {
     allSelectorKey?: string;

--- a/frontend/public/extend/devconsole/shared/components/dropdown/AppDropdown.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/AppDropdown.tsx
@@ -6,6 +6,7 @@ import { Firehose } from '../../../../../components/utils';
 
 interface AppDropdownProps {
   className?: string;
+  dropDownClassName?: string;
   menuClassName?: string;
   buttonClassName?: string;
   title?: React.ReactNode;
@@ -14,6 +15,10 @@ interface AppDropdownProps {
   storageKey?: string;
   canFavorite?: boolean;
   disabled?: boolean;
+  allSelectorItem?: {
+    allSelectorKey?: string;
+    allSelectorTitle?: string;
+  }
   namespace?: string;
   actionItem?: {
     actionTitle: string;
@@ -43,7 +48,6 @@ const AppDropdown: React.FC<AppDropdownProps> = (props) => {
       <LabelDropdown
         {...props}
         placeholder="Select an Application"
-        labelType="Application"
         labelSelector="app.kubernetes.io/part-of"
       />
     </Firehose>

--- a/frontend/public/extend/devconsole/shared/components/dropdown/AppNameSelector.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/AppNameSelector.tsx
@@ -35,7 +35,7 @@ const AppNameSelector: React.FC<AppNameSelectorProps> = ({
       <FormGroup>
         <ControlLabel className="co-required">Application</ControlLabel>
         <AppDropdown
-          className="dropdown--full-width"
+          dropDownClassName="dropdown--full-width"
           menuClassName="dropdown-menu--text-wrap"
           namespace={namespace}
           actionItem={{

--- a/frontend/public/extend/devconsole/shared/components/dropdown/AppNameSelector.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/AppNameSelector.tsx
@@ -35,6 +35,8 @@ const AppNameSelector: React.FC<AppNameSelectorProps> = ({
       <FormGroup>
         <ControlLabel className="co-required">Application</ControlLabel>
         <AppDropdown
+          className="dropdown--full-width"
+          menuClassName="dropdown-menu--text-wrap"
           namespace={namespace}
           actionItem={{
             actionTitle: 'Create New Application',

--- a/frontend/public/extend/devconsole/shared/components/dropdown/LabelDropdown.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/LabelDropdown.tsx
@@ -25,7 +25,6 @@ interface LabelDropdownProps {
   titlePrefix?: string;
   allApplicationsKey?: string;
   storageKey?: string;
-  canFavorite?: boolean;
   disabled?: boolean;
   allSelectorItem?: {
     allSelectorKey?: string;
@@ -55,7 +54,7 @@ class LabelDropdown extends React.Component<LabelDropdownProps, LabelDropdownSta
   };
 
   autocompleteFilter(text, item) {
-    return fuzzy(text, item.props.name);
+    return fuzzy(text, item);
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -150,7 +149,6 @@ class LabelDropdown extends React.Component<LabelDropdownProps, LabelDropdownSta
         title={this.props.title || this.state.title}
         autocompletePlaceholder={this.props.placeholder}
         storageKey={this.props.storageKey}
-        canFavorite={this.props.canFavorite}
         disabled={this.props.disabled}
       />
     );

--- a/frontend/public/extend/devconsole/shared/components/dropdown/LabelDropdown.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/LabelDropdown.tsx
@@ -98,18 +98,20 @@ class LabelDropdown extends React.Component<LabelDropdownProps, LabelDropdownSta
       );
     });
 
+    const sortedList = {};
+
     if (this.props.allSelectorItem && !_.isEmpty(unsortedList)) {
-      unsortedList[allSelectorItem.allSelectorKey] = {
+      sortedList[allSelectorItem.allSelectorKey] = {
         name: allSelectorItem.allSelectorTitle,
       };
     }
 
-    const sortedList = {};
     _.keys(unsortedList)
       .sort()
       .forEach((key) => {
         sortedList[key] = unsortedList[key];
       });
+    
     this.setState({ items: sortedList });
   }
 

--- a/frontend/public/extend/devconsole/shared/components/dropdown/LabelDropdown.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/LabelDropdown.tsx
@@ -18,6 +18,7 @@ interface LabelDropdownState {
 
 interface LabelDropdownProps {
   className?: string;
+  dropDownClassName?: string;
   menuClassName?: string;
   buttonClassName?: string;
   title?: React.ReactNode;
@@ -26,12 +27,15 @@ interface LabelDropdownProps {
   storageKey?: string;
   canFavorite?: boolean;
   disabled?: boolean;
+  allSelectorItem?: {
+    allSelectorKey?: string;
+    allSelectorTitle?: string;
+  };
   actionItem?: {
     actionTitle: string;
     actionKey: string;
   };
   labelSelector: string;
-  labelType: string;
   loaded?: boolean;
   loadError?: string;
   placeholder?: string;
@@ -62,7 +66,7 @@ class LabelDropdown extends React.Component<LabelDropdownProps, LabelDropdownSta
   }
 
   componentWillReceiveProps(nextProps: LabelDropdownProps) {
-    const { labelSelector, resources, loaded, loadError, placeholder } = nextProps;
+    const { labelSelector, resources, loaded, loadError, placeholder, allSelectorItem } = nextProps;
     if (!loaded) {
       this.setState({ title: <LoadingInline /> });
       return;
@@ -95,9 +99,10 @@ class LabelDropdown extends React.Component<LabelDropdownProps, LabelDropdownSta
       );
     });
 
-    const allApplications = { name: 'all applications' };
-    if (this.props.allApplicationsKey && !_.isEmpty(unsortedList)) {
-      unsortedList[this.props.allApplicationsKey] = allApplications;
+    if (this.props.allSelectorItem && !_.isEmpty(unsortedList)) {
+      unsortedList[allSelectorItem.allSelectorKey] = {
+        name: allSelectorItem.allSelectorTitle,
+      };
     }
 
     const sortedList = {};
@@ -133,6 +138,7 @@ class LabelDropdown extends React.Component<LabelDropdownProps, LabelDropdownSta
     return (
       <Dropdown
         className={this.props.className}
+        dropDownClassName={this.props.dropDownClassName}
         menuClassName={this.props.menuClassName}
         buttonClassName={this.props.buttonClassName}
         titlePrefix={this.props.titlePrefix}

--- a/frontend/public/extend/devconsole/shared/components/dropdown/LabelDropdown.tsx
+++ b/frontend/public/extend/devconsole/shared/components/dropdown/LabelDropdown.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';
 
-import { Dropdown, ResourceName, LoadingInline } from '../../../../../components/utils';
+import { Dropdown, LoadingInline } from '../../../../../components/utils';
 import { K8sResourceKind } from '../../../../../module/k8s';
 
 type FirehoseList = {
@@ -17,6 +17,15 @@ interface LabelDropdownState {
 }
 
 interface LabelDropdownProps {
+  className?: string;
+  menuClassName?: string;
+  buttonClassName?: string;
+  title?: React.ReactNode;
+  titlePrefix?: string;
+  allApplicationsKey?: string;
+  storageKey?: string;
+  canFavorite?: boolean;
+  disabled?: boolean;
   actionItem?: {
     actionTitle: string;
     actionKey: string;
@@ -86,6 +95,11 @@ class LabelDropdown extends React.Component<LabelDropdownProps, LabelDropdownSta
       );
     });
 
+    const allApplications = { name: 'all applications' };
+    if (this.props.allApplicationsKey && !_.isEmpty(unsortedList)) {
+      unsortedList[this.props.allApplicationsKey] = allApplications;
+    }
+
     const sortedList = {};
     _.keys(unsortedList)
       .sort()
@@ -97,13 +111,12 @@ class LabelDropdown extends React.Component<LabelDropdownProps, LabelDropdownSta
 
   onChange = (key) => {
     const { name } = _.get(this.state, ['items', key], {});
-    const { labelType } = this.props;
-    const { actionKey, actionTitle } = this.props.actionItem;
+    const { actionItem } = this.props;
     let title;
-    if (key === actionKey) {
-      title = <span className="btn-dropdown__item--placeholder">{actionTitle}</span>;
+    if (actionItem && key === actionItem.actionKey) {
+      title = <span className="btn-dropdown__item--placeholder">{actionItem.actionTitle}</span>;
     } else {
-      title = <ResourceName kind={labelType} name={name} />;
+      title = <span>{name}</span>;
     }
     this.props.onChange(name, key);
     this.setState({ title });
@@ -111,22 +124,28 @@ class LabelDropdown extends React.Component<LabelDropdownProps, LabelDropdownSta
 
   render() {
     const items = {};
+
     _.keys(this.state.items).forEach((key) => {
       const item = this.state.items[key];
-      items[key] = <ResourceName kind={this.props.labelType} name={item.name} />;
+      items[key] = item.name;
     });
 
     return (
       <Dropdown
+        className={this.props.className}
+        menuClassName={this.props.menuClassName}
+        buttonClassName={this.props.buttonClassName}
+        titlePrefix={this.props.titlePrefix}
         autocompleteFilter={this.autocompleteFilter}
         actionItem={this.props.actionItem}
         items={items}
         onChange={this.onChange}
         selectedKey={this.props.selectedKey}
-        title={this.state.title}
+        title={this.props.title || this.state.title}
         autocompletePlaceholder={this.props.placeholder}
-        dropDownClassName="dropdown--full-width"
-        menuClassName="dropdown-menu--text-wrap"
+        storageKey={this.props.storageKey}
+        canFavorite={this.props.canFavorite}
+        disabled={this.props.disabled}
       />
     );
   }

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -6,6 +6,7 @@ import {
   ALL_NAMESPACES_KEY,
   LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
   LAST_PERSPECTIVE_LOCAL_STORAGE_KEY,
+  LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY,
 } from '../const';
 import { getNSPrefix } from '../components/utils/link';
 import { allModels } from '../module/k8s/k8s-models';
@@ -26,6 +27,7 @@ allModels().forEach((v, k) => {
 });
 
 export const getActiveNamespace = () => store.getState().UI.get('activeNamespace');
+export const getActiveApplication = () => store.getState().UI.get('activeApplication');
 
 export const formatNamespacedRouteForResource = (resource, activeNamespace=getActiveNamespace()) => {
   return activeNamespace === ALL_NAMESPACES_KEY
@@ -76,6 +78,7 @@ export const types = {
   selectOverviewItem: 'selectOverviewItem',
   selectOverviewView: 'selectOverviewView',
   setActiveNamespace: 'setActiveNamespace',
+  setActiveApplication: 'setActiveApplication',
   setActivePerspective: 'setActivePerspective',
   setCreateProjectMessage: 'setCreateProjectMessage',
   setClusterID: 'setClusterID',
@@ -117,6 +120,23 @@ export const UIActions = {
     return {
       type: types.setActiveNamespace,
       value: namespace,
+    };
+  },
+
+  [types.setActiveApplication]: (application) => {
+    if (application) {
+      application = application.trim();
+    }
+
+    if (application !== getActiveApplication()) {
+      // remember the most recently-viewed project, which is automatically
+      // selected when returning to the console
+      localStorage.setItem(LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY, application);
+    }
+
+    return {
+      type: types.setActiveApplication,
+      value: application,
     };
   },
 

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -127,10 +127,6 @@ export const UIActions = {
       application = application.trim();
     }
 
-    // remember the most recently-viewed application, which is automatically
-    // selected when returning to the console
-    localStorage.setItem(LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY, application);
-
     return {
       type: types.setActiveApplication,
       value: application,

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -127,9 +127,8 @@ export const UIActions = {
     if (application) {
       application = application.trim();
     }
-
     if (application !== getActiveApplication()) {
-      // remember the most recently-viewed project, which is automatically
+      // remember the most recently-viewed application, which is automatically
       // selected when returning to the console
       localStorage.setItem(LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY, application);
     }

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -27,7 +27,6 @@ allModels().forEach((v, k) => {
 });
 
 export const getActiveNamespace = () => store.getState().UI.get('activeNamespace');
-export const getActiveApplication = () => store.getState().UI.get('activeApplication');
 
 export const formatNamespacedRouteForResource = (resource, activeNamespace=getActiveNamespace()) => {
   return activeNamespace === ALL_NAMESPACES_KEY
@@ -127,11 +126,10 @@ export const UIActions = {
     if (application) {
       application = application.trim();
     }
-    if (application !== getActiveApplication()) {
-      // remember the most recently-viewed application, which is automatically
-      // selected when returning to the console
-      localStorage.setItem(LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY, application);
-    }
+
+    // remember the most recently-viewed application, which is automatically
+    // selected when returning to the console
+    localStorage.setItem(LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY, application);
 
     return {
       type: types.setActiveApplication,

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -6,7 +6,6 @@ import {
   ALL_NAMESPACES_KEY,
   LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
   LAST_PERSPECTIVE_LOCAL_STORAGE_KEY,
-  LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY,
 } from '../const';
 import { getNSPrefix } from '../components/utils/link';
 import { allModels } from '../module/k8s/k8s-models';

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import { Map as ImmutableMap } from 'immutable';
 
 import { types } from './ui-actions';
-import { ALL_NAMESPACES_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, NAMESPACE_LOCAL_STORAGE_KEY, LAST_PERSPECTIVE_LOCAL_STORAGE_KEY, ALL_APPLICATIONS_KEY, LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY, APPLICATION_LOCAL_STORAGE_KEY } from '../const';
+import { ALL_NAMESPACES_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, NAMESPACE_LOCAL_STORAGE_KEY, LAST_PERSPECTIVE_LOCAL_STORAGE_KEY, LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY } from '../const';
 import { AlertStates, isSilenced, SilenceStates } from '../monitoring';
 import { legalNamePattern, getNamespace, getPerspective, defaultPerspective } from '../components/utils/link';
 
@@ -10,6 +10,7 @@ export default (state, action) => {
   if (!state) {
     const { pathname } = window.location;
     const lastPerspective = localStorage.getItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY);
+    const lastApplication = localStorage.getItem(LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY);
 
     let activeNamespace = getNamespace(pathname);
     if (!activeNamespace) {
@@ -18,16 +19,6 @@ export default (state, action) => {
         activeNamespace = parsedFavorite;
       } else {
         activeNamespace = localStorage.getItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
-      }
-    }
-
-    let activeApplication;
-    if (!activeApplication) {
-      const parsedFavorite = localStorage.getItem(APPLICATION_LOCAL_STORAGE_KEY);
-      if (_.isString(parsedFavorite) && (parsedFavorite.match(legalNamePattern) || parsedFavorite === ALL_APPLICATIONS_KEY)) {
-        activeApplication = parsedFavorite;
-      } else {
-        activeApplication = localStorage.getItem(LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY);
       }
     }
 
@@ -40,7 +31,7 @@ export default (state, action) => {
       activeNavSectionId: 'workloads',
       location: pathname,
       activeNamespace: activeNamespace || 'default',
-      activeApplication,
+      activeApplication: lastApplication,
       activePerspective: activePerspective || defaultPerspective,
       createProjectMessage: '',
       overview: new ImmutableMap({
@@ -66,7 +57,6 @@ export default (state, action) => {
 
     case types.setActiveApplication:
       return state.set('activeApplication', action.value);
-
 
     case types.setActivePerspective:
       return state.set('activePerspective', action.value);

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import { Map as ImmutableMap } from 'immutable';
 
 import { types } from './ui-actions';
-import { ALL_NAMESPACES_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, NAMESPACE_LOCAL_STORAGE_KEY, LAST_PERSPECTIVE_LOCAL_STORAGE_KEY, LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY } from '../const';
+import { ALL_NAMESPACES_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, NAMESPACE_LOCAL_STORAGE_KEY, LAST_PERSPECTIVE_LOCAL_STORAGE_KEY, ALL_APPLICATIONS_KEY } from '../const';
 import { AlertStates, isSilenced, SilenceStates } from '../monitoring';
 import { legalNamePattern, getNamespace, getPerspective, defaultPerspective } from '../components/utils/link';
 
@@ -10,7 +10,6 @@ export default (state, action) => {
   if (!state) {
     const { pathname } = window.location;
     const lastPerspective = localStorage.getItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY);
-    const lastApplication = localStorage.getItem(LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY);
 
     let activeNamespace = getNamespace(pathname);
     if (!activeNamespace) {
@@ -31,7 +30,7 @@ export default (state, action) => {
       activeNavSectionId: 'workloads',
       location: pathname,
       activeNamespace: activeNamespace || 'default',
-      activeApplication: lastApplication,
+      activeApplication: ALL_APPLICATIONS_KEY,
       activePerspective: activePerspective || defaultPerspective,
       createProjectMessage: '',
       overview: new ImmutableMap({
@@ -53,6 +52,7 @@ export default (state, action) => {
         console.warn('setActiveNamespace: Not setting to falsy!');
         return state;
       }
+      state = state.set('activeApplication', ALL_APPLICATIONS_KEY);
       return state.set('activeNamespace', action.value);
 
     case types.setActiveApplication:

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -2,13 +2,14 @@ import * as _ from 'lodash-es';
 import { Map as ImmutableMap } from 'immutable';
 
 import { types } from './ui-actions';
-import { ALL_NAMESPACES_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, NAMESPACE_LOCAL_STORAGE_KEY, LAST_PERSPECTIVE_LOCAL_STORAGE_KEY } from '../const';
+import { ALL_NAMESPACES_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, NAMESPACE_LOCAL_STORAGE_KEY, LAST_PERSPECTIVE_LOCAL_STORAGE_KEY, ALL_APPLICATIONS_KEY, LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY, APPLICATION_LOCAL_STORAGE_KEY } from '../const';
 import { AlertStates, isSilenced, SilenceStates } from '../monitoring';
 import { legalNamePattern, getNamespace, getPerspective, defaultPerspective } from '../components/utils/link';
 
 export default (state, action) => {
   if (!state) {
     const { pathname } = window.location;
+    const lastPerspective = localStorage.getItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY);
 
     let activeNamespace = getNamespace(pathname);
     if (!activeNamespace) {
@@ -20,7 +21,16 @@ export default (state, action) => {
       }
     }
 
-    const lastPerspective = localStorage.getItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY);
+    let activeApplication;
+    if (!activeApplication) {
+      const parsedFavorite = localStorage.getItem(APPLICATION_LOCAL_STORAGE_KEY);
+      if (_.isString(parsedFavorite) && (parsedFavorite.match(legalNamePattern) || parsedFavorite === ALL_APPLICATIONS_KEY)) {
+        activeApplication = parsedFavorite;
+      } else {
+        activeApplication = localStorage.getItem(LAST_APPLICATION_NAME_LOCAL_STORAGE_KEY);
+      }
+    }
+
     let activePerspective = getPerspective(pathname);
     if (pathname === '/' && lastPerspective !== activePerspective) {
       activePerspective = lastPerspective;
@@ -30,6 +40,7 @@ export default (state, action) => {
       activeNavSectionId: 'workloads',
       location: pathname,
       activeNamespace: activeNamespace || 'default',
+      activeApplication,
       activePerspective: activePerspective || defaultPerspective,
       createProjectMessage: '',
       overview: new ImmutableMap({
@@ -52,6 +63,10 @@ export default (state, action) => {
         return state;
       }
       return state.set('activeNamespace', action.value);
+
+    case types.setActiveApplication:
+      return state.set('activeApplication', action.value);
+
 
     case types.setActivePerspective:
       return state.set('activePerspective', action.value);

--- a/frontend/public/ui/ui-selectors.js
+++ b/frontend/public/ui/ui-selectors.js
@@ -1,1 +1,2 @@
 export const getActivePerspective = state => state.UI.get('activePerspective');
+export const getActiveApplication = state => state.UI.get('activeApplication');


### PR DESCRIPTION
Story: https://jira.coreos.com/browse/ODC-435

This PR adds `ApplicationSwitcher` in the context bar

Currently the `NamespaceDropdown` handles favorite application in a way that if the user favorites an application and if the URL doesn't have a namespace, instead of the `lastNamespace` viewed the favorite application gets displayed in the title and gets set as the `activeNamespace`. But this logic will not work for `ApplicationSwitcher` because it depends upon the currently selected namespace and the title should not show an application favorited under a different namespace to show up in all other namespaces. In this PR I am not setting the favorited application in the title, it will just show up in the dropdown list as shown in the gif. Also in `NamespaceDropdown` if a different namespace is selected then it gets set as the actievNamespace and displayed in the title so for `ApplicationSwitcher` there are two options either to not display the `lastViewed` application in the title for all the `namespaces` or show in all the namespaces. cc @serenamarie125 

Also this PR fixes a bug in `dropdown.tsx`. So when an `item` is bookmarked it gets stored in the local storage in the array of bookmarked items and `dropdown.tsx` gets the array of bookmarks from local storage and appends these bookmarks to the list of `items` sent by parent to show the bookmarked `items` in the dropdown, but it introduces a bug wherein even if an `item` was bookmarked but is no more available in the list of `items` sent by parent it still shows in the dropdown list because of the above logic. Fixed this by checking if the respective `item` is available in `items` sent by parent.

![appswitcher2](https://user-images.githubusercontent.com/20724543/57617118-9f091a80-759d-11e9-80b6-b48314703054.gif)



