### PR TITLE
[Obsolete]add part-of label to resources created using import-yaml

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -35,6 +35,8 @@ const generateObjToLoad = (kind, templateName, namespace = 'default') => {
 };
 
 const stateToProps = ({k8s, UI}) => ({
+  activePerspective: UI.get('activePerspective'),
+  activeApplication: UI.get('activeApplication'),
   activeNamespace: UI.get('activeNamespace'),
   models: k8s.getIn(['RESOURCES', 'models']),
 });
@@ -245,6 +247,8 @@ export const EditYAML = connect(stateToProps)(
       if (!obj.metadata.namespace && model.namespaced) {
         obj.metadata.namespace = this.props.activeNamespace;
       }
+
+      obj.metadata.labels = { 'app.kubernetes.io/part-of': this.props.activeApplication, ...obj.metadata.labels };
 
       const { namespace: newNamespace, name: newName } = obj.metadata;
 

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -19,6 +19,7 @@ import { coFetchJSON } from '../co-fetch';
 import { ResourceSidebar } from './sidebars/resource-sidebar';
 import { yamlTemplates } from '../models/yaml-templates';
 import { SWAGGER_SESSION_STORAGE_KEY } from '../const';
+import { getAppLabels } from '../extend/devconsole/utils/resource-label-utils';
 
 const { snippetManager } = ace.acequire('ace/snippets');
 snippetManager.register([...snippets.values()], 'yaml');
@@ -248,7 +249,10 @@ export const EditYAML = connect(stateToProps)(
         obj.metadata.namespace = this.props.activeNamespace;
       }
 
-      obj.metadata.labels = { 'app.kubernetes.io/part-of': this.props.activeApplication, ...obj.metadata.labels };
+      if (['DeploymentConfig', 'Deployment', 'Pod', 'Service', 'Route'].includes(obj.kind)) {
+        const appLabels = getAppLabels(obj.metadata.name, this.props.activeApplication);
+        obj.metadata.labels = { ...appLabels, ...obj.metadata.labels };
+      }
 
       const { namespace: newNamespace, name: newName } = obj.metadata;
 

--- a/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
+++ b/frontend/public/extend/devconsole/components/application-switcher/ApplicationSwitcher.tsx
@@ -48,7 +48,7 @@ const ApplicationSwitcher: React.FC<ApplicationSwitcherProps> = ({
         allSelectorKey: ALL_APPLICATIONS_KEY,
         allSelectorTitle: allApplicationsTitle,
       }}
-      selectedKey={application || ALL_APPLICATIONS_KEY}
+      selectedKey={application}
       onChange={onApplicationChange}
       storageKey={APPLICATION_LOCAL_STORAGE_KEY}
       disabled={disabled}

--- a/frontend/public/extend/devconsole/utils/resource-label-utils.ts
+++ b/frontend/public/extend/devconsole/utils/resource-label-utils.ts
@@ -1,4 +1,4 @@
-export const getAppLabels = (name: string, application: string, imageStreamName: string) => {
+export const getAppLabels = (name: string, application: string, imageStreamName?: string) => {
   return {
     app: name,
     'app.kubernetes.io/part-of': application,


### PR DESCRIPTION
Story - https://jira.coreos.com/browse/ODC-594

This PR  implements adding of `part-of` label with value as `activeApplication` to the resources created by importing YAML. 

Currently checking if the user is in `dev` perspective, then only adding the label.

![label](https://user-images.githubusercontent.com/20724543/57845461-b3dcec80-77ef-11e9-9ed8-cc0322a2f9cd.gif)
