### PR TITLE
feat(topology): add additional controls to the toolbar

### DIFF
--- a/frontend/public/extend/devconsole/components/topology/GraphToolbar.scss
+++ b/frontend/public/extend/devconsole/components/topology/GraphToolbar.scss
@@ -1,14 +1,10 @@
 .odc-graph-toolbar {
   position: absolute;
-  bottom: 12px;
-  left: 16px;
-  max-width: calc(100% - 32px);
+  bottom: calc(var(--pf-global--spacer--md) - var(--pf-global--spacer--xs));
+  left: var(--pf-global--spacer--md);
+  max-width: calc(100% - var(--pf-global--spacer--md) * 2);
 
   & > * {
-    margin: 0 4px 4px 0;
-    width: 32px;
-    height: 32px;
-    display: inline-flex;
-    justify-content: center;
+    margin: 0 var(--pf-global--spacer--xs) var(--pf-global--spacer--xs) 0;
   }
 }

--- a/frontend/public/extend/devconsole/components/topology/GraphToolbarButton.scss
+++ b/frontend/public/extend/devconsole/components/topology/GraphToolbarButton.scss
@@ -1,0 +1,21 @@
+.odc-graph-toolbar-button {
+  height: 32px;
+  padding: 0 8px;
+  min-width: 40px;
+  color: var(--pf-global--Color--100);
+  background-color: var(--pf-global--Color--light-100);
+  border-radius: 4px;
+  border: 0;
+  transition: color 0.2s ease;
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: var(--pf-global--BoxShadow--sm);
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: var(--pf-global--primary-color--100);
+  }
+}

--- a/frontend/public/extend/devconsole/components/topology/GraphToolbarButton.tsx
+++ b/frontend/public/extend/devconsole/components/topology/GraphToolbarButton.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import './GraphToolbarButton.scss';
+
+export interface GraphToolbarButtonProps {
+  label: string;
+  children: React.ReactNode;
+  onClick(): void;
+}
+
+const GraphToolbarButton: React.FC<GraphToolbarButtonProps> = ({ label, onClick, children }) => (
+  // set enableFlip to false for now because PF does not properly align the arrow
+  <Tooltip content={label} position={TooltipPosition.top} enableFlip={false}>
+    <button className="odc-graph-toolbar-button" onClick={onClick} aria-label={label}>
+      {children}
+    </button>
+  </Tooltip>
+);
+
+export default GraphToolbarButton;

--- a/frontend/public/extend/devconsole/components/topology/Topology.tsx
+++ b/frontend/public/extend/devconsole/components/topology/Topology.tsx
@@ -1,12 +1,17 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
-import { Button } from 'patternfly-react';
-import { ExpandIcon, SearchPlusIcon, SearchMinusIcon } from '@patternfly/react-icons';
+import {
+  ExpandIcon,
+  ExpandArrowsAltIcon,
+  SearchPlusIcon,
+  SearchMinusIcon,
+} from '@patternfly/react-icons';
 import { nodeProvider, edgeProvider, groupProvider } from './shape-providers';
 import Graph from './Graph';
 import GraphToolbar from './GraphToolbar';
 import { GraphApi, TopologyDataModel } from './topology-types';
 import TopologySideBar from './TopologySideBar';
+import GraphToolbarButton from './GraphToolbarButton';
 
 type State = {
   selected?: string;
@@ -17,9 +22,7 @@ export interface TopologyProps {
 }
 
 export default class Topology extends React.Component<TopologyProps, State> {
-  state: State = {
-    selected: null,
-  };
+  state: State = {};
 
   static getDerivedStateFromProps(nextProps: TopologyProps, prevState: State): State {
     const { selected } = prevState;
@@ -41,22 +44,23 @@ export default class Topology extends React.Component<TopologyProps, State> {
 
   renderToolbar = (graphApi: GraphApi) => (
     <GraphToolbar>
-      <Button onClick={graphApi.zoomIn} title="Zoom In" aria-label="Zoom In">
+      <GraphToolbarButton label="Zoom In" onClick={graphApi.zoomIn}>
         <SearchPlusIcon />
-      </Button>
-      <Button onClick={graphApi.zoomOut} title="Zoom Out" aria-label="Zoom Out">
+      </GraphToolbarButton>
+      <GraphToolbarButton label="Zoom Out" onClick={graphApi.zoomOut}>
         <SearchMinusIcon />
-      </Button>
-      <Button onClick={graphApi.resetView} title="Reset Zoom" aria-label="Reset Zoom">
+      </GraphToolbarButton>
+      <GraphToolbarButton label="Fit to Screen" onClick={graphApi.zoomFit}>
+        <ExpandArrowsAltIcon />
+      </GraphToolbarButton>
+      <GraphToolbarButton label="Reset Layout" onClick={graphApi.resetLayout}>
         <ExpandIcon />
-      </Button>
+      </GraphToolbarButton>
     </GraphToolbar>
   );
 
   render() {
-    const {
-      data: { graph, topology },
-    } = this.props;
+    const { data: { graph, topology } } = this.props;
     const { selected } = this.state;
     return (
       <React.Fragment>

--- a/frontend/public/extend/devconsole/components/topology/topology-types.ts
+++ b/frontend/public/extend/devconsole/components/topology/topology-types.ts
@@ -90,7 +90,9 @@ export interface WorkloadData {
 export interface GraphApi {
   zoomIn(): void;
   zoomOut(): void;
-  resetView(): void;
+  zoomReset(): void;
+  zoomFit(): void;
+  resetLayout(): void;
 }
 
 export interface Selectable {


### PR DESCRIPTION
- adds a fit to screen button to center the layout and set the zoom level such that the entire topology is visible on screen
- replaced 'reset zoom' button with reset layout which will re-run the entire layout. This is useful to fix layouts that have been dragged around by the user
- update styling of controls and added pf tooltips

![topology-controls](https://user-images.githubusercontent.com/14068621/57944611-89e60180-78a5-11e9-83b8-5d10a0e80660.gif)


