### PR TITLE
improve topology grouping convex hull

### DIFF
--- a/frontend/public/extend/devconsole/components/topology/shapes/DefaultGroup.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/DefaultGroup.tsx
@@ -1,21 +1,20 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import * as d3 from 'd3';
-import { GroupProps, ViewNode } from '../topology-types';
+import * as _ from 'lodash-es';
+import { GroupProps } from '../topology-types';
 import SvgBoxedText from '../../../shared/components/svg/SvgBoxedText';
+import { hullPath } from '../../../shared/utils/svg-utils';
 import './DefaultGroup.scss';
 
-const valueline = d3
-  .line()
-  .x((d) => d[0])
-  .y((d) => d[1])
-  .curve(d3.curveBasisClosed);
+type Point = [number, number];
+type PointWithSize = Point & [number, number, number];
 
 // Return the point whose Y is the largest value.
-function findLowestPoint(points: [number, number][]): [number, number] {
+function findLowestPoint<P extends Point>(points: P[]): P {
   let lowestPoint = points[0];
 
-  points.forEach((p) => {
+  _.forEach(points, (p) => {
     if (p[1] > lowestPoint[1]) {
       lowestPoint = p;
     }
@@ -24,68 +23,32 @@ function findLowestPoint(points: [number, number][]): [number, number] {
   return lowestPoint;
 }
 
-// Padding around group points in pixels.
-const GP = 50;
-
-// Returns an array of points representing 8 points around the center of the node.
-// We use these points to ensure that the surrounding group box does not intersect with the node.
-function getNodePoints(node: ViewNode): [number, number][] {
-  const radius = node.size / 2;
-  const x0 = node.x - radius;
-  const x1 = node.x + radius;
-  const y0 = node.y - radius;
-  const y1 = node.y + radius;
-  return [
-    ...[45, 135, 225, 315].map(
-      (θ) =>
-        [
-          node.x + (radius + GP) * Math.sin(θ * Math.PI / 180),
-          node.y + (radius + GP) * Math.cos(θ * Math.PI / 180),
-        ] as [number, number],
-    ),
-    [node.x, y0 - GP],
-    [node.x, y1 + GP],
-    [x0 - GP, node.y],
-    [x1 + GP, node.y],
-  ];
-}
+const hullPadding = (point: PointWithSize) => point[2] + 40;
 
 const DefaultGroup: React.FC<GroupProps> = ({ name, nodes }) => {
   if (nodes.length === 0) {
     return null;
   }
 
-  // collect all points to avoid for all nodes
-  const points = nodes.reduce((acc, node) => [...acc, ...getNodePoints(node)], [] as [
-    number,
-    number
-  ][]);
+  // convert nodes to points
+  const points: PointWithSize[] = new Array(nodes.length);
+  _.forEach(nodes, (node, i) => {
+    points[i] = [node.x, node.y, node.size / 2] as PointWithSize;
+  });
 
   // Get the convex hull of all points.
-  const polygon = d3.polygonHull(points);
-
-  // Find the cenroid of the convex hull
-  const centroid = d3.polygonCentroid(polygon);
-
-  // Convert the convex hull to a set of points to be used for the surrounding path.
-  const dPoints = polygon.map(
-    (point) => [point[0] - centroid[0], point[1] - centroid[1]] as [number, number],
-  );
+  const d = hullPath(points.length > 2 ? d3.polygonHull(points) : points, hullPadding);
 
   // Find the lowest point of the set in order to place the group label.
-  const lowestPoint = findLowestPoint(dPoints);
+  const lowestPoint = findLowestPoint(points);
 
   return (
     <g>
-      <path
-        d={valueline(dPoints)}
-        className="odc-default-group"
-        transform={`translate(${centroid[0]},${centroid[1]})`}
-      />
+      <path d={d} className="odc-default-group" />
       <SvgBoxedText
         className={'odc-default-group__label'}
-        x={centroid[0] + lowestPoint[0]}
-        y={centroid[1] + lowestPoint[1] + 30}
+        x={lowestPoint[0]}
+        y={lowestPoint[1] + hullPadding(lowestPoint) + 30}
         paddingX={20}
         paddingY={5}
       >

--- a/frontend/public/extend/devconsole/shared/utils/svg-utils.ts
+++ b/frontend/public/extend/devconsole/shared/utils/svg-utils.ts
@@ -1,3 +1,92 @@
 export function createFilterIdUrl(id: string): string {
   return `url(${`${location.pathname}${location.search}`}#${id})`;
 }
+
+export type Point = [number, number];
+export type HullPaddingGetter = (point: Point) => number;
+
+// Returns the vector 'v' scaled by 'scale'.
+function vecScale(scale: number, v: Point): Point {
+  return [scale * v[0], scale * v[1]];
+}
+
+// Returns the sum of two vectors, or a combination of a point and a vector.
+function vecSum(pv1: Point, pv2: Point): Point {
+  return [pv1[0] + pv2[0], pv1[1] + pv2[1]];
+}
+
+// Returns the unit normal to the line segment from p0 to p1.
+function unitNormal(p0: Point, p1: Point): Point {
+  const n = [p0[1] - p1[1], p1[0] - p0[0]];
+  const nLength = Math.sqrt(n[0] * n[0] + n[1] * n[1]);
+  return [n[0] / nLength, n[1] / nLength];
+}
+
+// Returns the path for a rounded hull around a single point (a circle).
+function roundedHull1(polyPoints: Point[], hp: HullPaddingGetter): string {
+  const padding = hp(polyPoints[0]);
+  const p1 = [polyPoints[0][0], polyPoints[0][1] - padding];
+  const p2 = [polyPoints[0][0], polyPoints[0][1] + padding];
+
+  return `M ${p1} A ${padding},${padding},0,0,0,${p2} A ${padding},${padding},0,0,0,${p1}}`;
+}
+
+// Returns the path for a rounded hull around two points (a "capsule" shape).
+function roundedHull2(polyPoints: Point[], hp: HullPaddingGetter): string {
+  const offsetVector1 = vecScale(hp(polyPoints[0]), unitNormal(polyPoints[0], polyPoints[1]));
+  const invOffsetVector1 = vecScale(-1, offsetVector1);
+
+  const offsetVector2 = vecScale(hp(polyPoints[1]), unitNormal(polyPoints[0], polyPoints[1]));
+  const invOffsetVector2 = vecScale(-1, offsetVector2);
+
+  const p0 = vecSum(polyPoints[0], offsetVector1);
+  const p1 = vecSum(polyPoints[1], offsetVector2);
+  const p2 = vecSum(polyPoints[1], invOffsetVector2);
+  const p3 = vecSum(polyPoints[0], invOffsetVector1);
+
+  return `M ${p0} L ${p1} A ${hp(polyPoints[1])},${hp(polyPoints[1])},0,0,0,${p2} L ${p3} A ${hp(
+    polyPoints[0],
+  )},${hp(polyPoints[0])},0,0,0,${p0}`;
+}
+
+// Returns the SVG path data string representing the polygon, expanded and rounded.
+export function hullPath(polyPoints: Point[], hullPadding: number | HullPaddingGetter = 0): string {
+  const hp = typeof hullPadding === 'number' ? () => hullPadding : hullPadding;
+
+  // Handle special cases
+  if (!polyPoints || polyPoints.length < 1) {
+    return '';
+  }
+  if (polyPoints.length === 1) {
+    return roundedHull1(polyPoints, hp);
+  }
+  if (polyPoints.length === 2) {
+    return roundedHull2(polyPoints, hp);
+  }
+
+  const segments: Point[][] = new Array(polyPoints.length);
+
+  // Calculate each offset (outwards) segment of the convex hull.
+  for (let segmentIndex = 0; segmentIndex < segments.length; ++segmentIndex) {
+    const p0 =
+      segmentIndex === 0 ? polyPoints[polyPoints.length - 1] : polyPoints[segmentIndex - 1];
+    const p1 = polyPoints[segmentIndex];
+
+    // Compute the offset vector for the line segment, with length = hullPadding.
+    // const offset = vecScale(hullPadding, unitNormal(p0, p1));
+    segments[segmentIndex] = [
+      vecSum(p0, vecScale(hp(p0), unitNormal(p0, p1))),
+      vecSum(p1, vecScale(hp(p1), unitNormal(p0, p1))),
+    ];
+  }
+
+  return segments
+    .map((segment, index) => {
+      const p0 = index === 0 ? polyPoints[polyPoints.length - 1] : polyPoints[index - 1];
+      const p1 = polyPoints[index];
+      return `${index === 0 ? `M ${segments[segments.length - 1][1]} ` : ''}A ${hp(p0)},${hp(
+        p1,
+      )},0,0,0,${segment[0]} L ${segment[1]}`;
+    })
+    .join(' ');
+}


### PR DESCRIPTION
This change improves the group outline such that it draws a perfect radius around the nodes. The original implementation was a quick fix that created 8 points per node prior to calculating the convex hull. The new implementation uses the node origin for the convex hull and then expands each point out to the edge perpendicular to the line created between two adjacent nodes. Then a path arc is used to draw a perfect radius.

In the before comparison it's noticeable where the group outline at times takes a short cut path to the next node resulting in irregular padding between the group edge and the node itself. Whereas the after implementation has a uniform padding between the group edge and the node all the way around.

Before:
![image](https://user-images.githubusercontent.com/14068621/57972575-88cad800-796a-11e9-880d-fee3a40280f9.png)

After:
![image](https://user-images.githubusercontent.com/14068621/57972654-916fde00-796b-11e9-9f75-5960eb89f34f.png)

Before: observe the group bouncing at the top of each nodes.
![hull1](https://user-images.githubusercontent.com/14068621/57972725-46a29600-796c-11e9-9853-0632dc7bdc38.gif)

After: always smooth
![hull2](https://user-images.githubusercontent.com/14068621/57972726-46a29600-796c-11e9-858a-f7410ba76921.gif)


