### PR TITLE
fix(git-type):hide git-type if detected

### DIFF
--- a/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
@@ -41,6 +41,7 @@ export interface State {
   isComponentCreated: boolean;
   isBuilderImageDetected: boolean;
   gitUrlValidationStatus: string;
+  isGitTypeVisible: boolean;
 }
 
 export interface Props {
@@ -70,6 +71,7 @@ const initialState: State = {
   isComponentCreated: false,
   gitUrlValidationStatus: '',
   isBuilderImageDetected: false,
+  isGitTypeVisible: false,
 };
 
 enum ErrorMessage {
@@ -109,6 +111,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
       isComponentCreated: false,
       gitUrlValidationStatus: '',
       isBuilderImageDetected: false,
+      isGitTypeVisible: false,
     };
   }
   private randomString = this.generateRandomString();
@@ -297,9 +300,12 @@ export class ImportFlowForm extends React.Component<Props, State> {
         this.setState({
           gitType: this.detectGitType(this.state.gitRepoUrl),
           gitTypeError: ErrorMessage.GitTypeError,
+          isGitTypeVisible: true,
         });
       } else {
-        this.setState({ gitType: this.detectGitType(this.state.gitRepoUrl) });
+        this.setState({ gitType: this.detectGitType(this.state.gitRepoUrl),
+          isGitTypeVisible: false,
+        });
       }
     }
   };
@@ -476,6 +482,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
       namespaceError,
       nameError,
       builderImageError,
+      isGitTypeVisible,
     } = this.state;
 
     const { imageStreams } = this.props;
@@ -485,7 +492,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
     }
 
     let gitTypeField, showGitValidationStatus;
-    if (gitType || gitTypeError) {
+    if (isGitTypeVisible) {
       gitTypeField = (
         <FormGroup controlId="import-git-type" className={gitTypeError ? 'has-error' : ''}>
           <ControlLabel className="co-required">Git Type</ControlLabel>

--- a/frontend/public/extend/devconsole/components/ImportFlowForm/__tests__/ImportFlowForm.spec.tsx
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/__tests__/ImportFlowForm.spec.tsx
@@ -133,6 +133,28 @@ describe('ImportFlowForm: ', () => {
     expect(importFlowForm.state().gitType).toBe('github');
   });
 
+  it('git-type should be hidden and state to be updated if able to detect git-type', () => {
+    const importFlowForm = shallow(<ImportFlowForm {...props} />);
+    const urlInput = importFlowForm.find('[data-test-id="import-git-repo-url"]');
+    urlInput.simulate('change', {
+      target: { value: 'https://github.com/vikram-raj/console/tree/import-flow' },
+    });
+    urlInput.simulate('blur');
+    expect(importFlowForm.state().gitType).toBe('github');
+    expect(importFlowForm.find('[controlId="import-git-type"]')).toHaveLength(0);
+  });
+
+  it('git-type should be shown if unable to detect git-type', () => {
+    const importFlowForm = shallow(<ImportFlowForm {...props} />);
+    const urlInput = importFlowForm.find('[data-test-id="import-git-repo-url"]');
+    urlInput.simulate('change', {
+      target: { value: 'https://source.ibm.com' },
+    });
+    urlInput.simulate('blur');
+    expect(importFlowForm.state().gitType).toBe('');
+    expect(importFlowForm.find('[controlId="import-git-type"]')).toHaveLength(1);
+  });
+
   it('validate URL', () => {
     const importFlowForm = shallow(<ImportFlowForm {...props} />);
     const urlInput = importFlowForm.find('[data-test-id="import-git-repo-url"]');
@@ -197,6 +219,7 @@ describe('ImportFlowForm: ', () => {
       selectedApplicationKey: '',
       selectedImage: 'perl',
       selectedImageTag: '5.16',
+      isGitTypeVisible: false,
     };
 
     expect(importFlowForm.state()).toEqual(importFormState);


### PR DESCRIPTION
Tracks ## https://jira.coreos.com/browse/ODC-706

Scenario: 

- user provides git url as : "https://github.com/eclipse/che-plugin-registry/"
- As git type is GitHub (able to identify with regex) don't show git-type field
- If at any point in time user changes git url to "http://source.ibm.com/" 
- As git type is not identified so show git type field as user can change it as per their choice

GIF ::  

![gitTypeHidden](https://user-images.githubusercontent.com/5129024/58026036-4bfe0d00-7b33-11e9-85ee-8f8081fe898b.gif)


