### PR TITLE
Use console-config configmap to determine if dev console is enabled

### DIFF
--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -197,15 +197,10 @@ const detectUser = dispatch => coFetchJSON('api/kubernetes/apis/user.openshift.i
     },
   );
 
-const devopsConsolePath = `${k8sBasePath}/apis/devconsole.openshift.io`;
 const detectDevConsole = dispatch => {
-  coFetchJSON(devopsConsolePath)
-    .then(
-      res => setFlag(dispatch, FLAGS.SHOW_DEV_CONSOLE, true),
-      err => _.get(err, 'response.status') === 404
-        ? setFlag(dispatch, FLAGS.SHOW_DEV_CONSOLE, false)
-        : handleError(err, FLAGS.SHOW_DEV_CONSOLE, dispatch, detectDevConsole)
-    );
+  if ( process.env.REACT_APP_SHOW_DEV_CONSOLE == "true" ){
+    setFlag(dispatch, FLAGS.SHOW_DEV_CONSOLE, true);
+  }
 };
 
 export const featureActions = [

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -196,12 +196,21 @@ const detectUser = dispatch => coFetchJSON('api/kubernetes/apis/user.openshift.i
       }
     },
   );
-
+  
+const consoleConfigPath = `${k8sBasePath}/api/v1/namespaces/openshift-config-managed/configmaps/console-public`;
 const detectDevConsole = dispatch => {
-  if ( process.env.REACT_APP_SHOW_DEV_CONSOLE == "true" ){
-    setFlag(dispatch, FLAGS.SHOW_DEV_CONSOLE, true);
-  }
-};
+  coFetchJSON(consoleConfigPath)
+  .then(
+    res => {
+      if (res.data.showDevConsole === "true") {
+        dispatch(setFlag(dispatch, FLAGS.SHOW_DEV_CONSOLE, true));
+      }
+    },
+    err => _.get(err, 'response.status') === 404 
+      ? setFlag(dispatch, FLAGS.SHOW_DEV_CONSOLE, false)
+      : handleError(err, FLAGS.SHOW_DEV_CONSOLE, dispatch, detectDevConsole)
+    );
+  };
 
 export const featureActions = [
   detectOpenShift,


### PR DESCRIPTION
There's a `rolebinding`
```
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: console-public
  namespace: openshift-config-managed
roleRef:
  kind: Role
  name: console-public
  apiGroup: rbac.authorization.k8s.io
subjects:
  - kind: Group
    name: system:authenticated
    apiGroup: rbac.authorization.k8s.io
```

which might enable UI to look up the configuration and see if devconsole is enabled.

Work-in-progress:
This PR needs changes in https://github.com/openshift/console-operator/ 