### PR TITLE
fix(pod): smooth out the pod animation transitions between phases

### DIFF
--- a/frontend/public/extend/devconsole/components/topology/shapes/PodStatus.tsx
+++ b/frontend/public/extend/devconsole/components/topology/shapes/PodStatus.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
+import * as _ from 'lodash-es';
 import { VictoryPie } from 'victory';
 import { Pod } from '../topology-types';
 import Tooltip from './../SvgPodTooltip';
@@ -21,79 +22,74 @@ type PodStatusProps = {
   showTooltip?: boolean;
 };
 
-const PodStatus: React.FC<PodStatusProps> = ({
-  innerRadius,
-  outerRadius,
-  x,
-  y,
-  data,
-  size,
-  standalone = false,
-  showTooltip = true,
-}) => {
-  const vData: PodData[] = [];
-  podStatus.forEach((pod) => {
-    let podNumber = 0;
-    data.forEach((element) => {
-      if (getPodStatus(element) === pod) {
-        podNumber += 1;
-      }
-    });
-    if (podNumber !== 0) {
-      vData.push({ x: pod, y: podNumber });
-    }
-  });
-  const tooltipEvent = showTooltip
-    ? [
-      {
-        target: 'data',
-        eventHandlers: {
-          onMouseOver: () => {
-            return [
-              {
-                target: 'labels',
-                mutation: (props) => {
-                  return { active: true };
+class PodStatus extends React.PureComponent<PodStatusProps> {
+  render() {
+    const {
+      innerRadius,
+      outerRadius,
+      x,
+      y,
+      data,
+      size,
+      standalone = false,
+      showTooltip = true,
+    } = this.props;
+    const vData: PodData[] = podStatus.map((pod) => ({
+      x: pod,
+      y: _.sumBy(data, (d) => +(getPodStatus(d) === pod)) || 0,
+    }));
+    const tooltipEvent = showTooltip
+      ? [
+        {
+          target: 'data',
+          eventHandlers: {
+            onMouseOver: () => {
+              return [
+                {
+                  target: 'labels',
+                  mutation: () => {
+                    return { active: true };
+                  },
                 },
-              },
-            ];
-          },
-          onMouseOut: () => {
-            return [
-              {
-                target: 'labels',
-                mutation: (props) => {
-                  return { active: false };
+              ];
+            },
+            onMouseOut: () => {
+              return [
+                {
+                  target: 'labels',
+                  mutation: () => {
+                    return { active: false };
+                  },
                 },
-              },
-            ];
+              ];
+            },
           },
         },
-      },
-    ]
-    : undefined;
-  return (
-    <VictoryPie
-      events={tooltipEvent}
-      animate={{
-        duration: 2000,
-      }}
-      standalone={standalone}
-      innerRadius={innerRadius}
-      radius={outerRadius}
-      groupComponent={x && y ? <g transform={`translate(${x}, ${y})`} /> : undefined}
-      data={vData}
-      height={size}
-      width={size}
-      labelComponent={<Tooltip x={size / 2} y={-12} />}
-      padAngle={2}
-      style={{
-        data: {
-          fill: ({ x }) => podColor[x],
-        },
-      }}
-    />
-  );
-};
+      ]
+      : undefined;
+    return (
+      <VictoryPie
+        events={tooltipEvent}
+        animate={{
+          duration: 2000,
+        }}
+        standalone={standalone}
+        innerRadius={innerRadius}
+        radius={outerRadius}
+        groupComponent={x && y ? <g transform={`translate(${x}, ${y})`} /> : undefined}
+        data={vData}
+        height={size}
+        width={size}
+        labelComponent={<Tooltip x={size / 2} y={-12} />}
+        padAngle={(d: PodData) => (d.y > 0 ? 2 : 0)}
+        style={{
+          data: {
+            fill: (d: PodData) => podColor[d.x],
+          },
+        }}
+      />
+    );
+  }
+}
 
 export default PodStatus;


### PR DESCRIPTION
The transitions between pod phases currently is harsh when transitioning between 0 or more in a single phase. This occurs because currently only the phases which have a pod count are included in the data set. Which means any phase with a pod count of 0 is omitted. Therefore the victory pie chart simply drops the segment instead of animating it.

The fix is to ensure all phases are present in the data set even if the number of pods in the phase is 0. This has a negative side effect where adjacent segments with 0 pods still show the `padAngle` between segments. To fix this, the `padAngle` is provided a datum function which we can use to provide a custom `padAngle` per segment. A segment representing a phase with 0 pods therefore gets a `padAngle` of 0.

Observe the hard transition between pending and terminating states:
![pod_before](https://user-images.githubusercontent.com/14068621/58199119-cba7eb00-7c9d-11e9-8b95-72a2d52e1d44.gif)

Always animates smoothly:
![pod_after](https://user-images.githubusercontent.com/14068621/58199118-cba7eb00-7c9d-11e9-85c2-e70dee1e1d86.gif)

line 85: fixed `no-shadow` eslint error
Changed `PodStatus` to be a `PureComponent` to reduce re-renders of `VictoryPie`. When we update console we can use `React.memo`