### PR TITLE
add create-route form component

### DIFF
--- a/frontend/public/extend/devconsole/shared/components/CreateRouteForm.tsx
+++ b/frontend/public/extend/devconsole/shared/components/CreateRouteForm.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import { FormControl, FormGroup, ControlLabel, HelpBlock, CheckBox } from 'patternfly-react';
+import { Dropdown } from '../../../../components/utils';
+import { K8sResourceKind } from '../../../../module/k8s';
+
+interface CreateRouteFormProps {
+  name?: string;
+  hostname?: string;
+  path?: string;
+  loadedServices?: boolean;
+  serviceOptions?: { [key: string]: React.ReactNode };
+  portOptions?: { [key: string]: React.ReactNode };
+  service?: K8sResourceKind;
+  targetPort?: string;
+  createRoute?: boolean;
+  createRouteOption?: boolean;
+  hostnameErrorMsg?: string;
+  pathErrorMsg?: string;
+  onInputChange?: (event: React.SyntheticEvent<HTMLInputElement>) => void;
+  onServiceChange?: (selectedKey: string) => void;
+  onTargetPortChange?: (selectedKey: string) => void;
+  onCreateRouteChange?: (event: React.SyntheticEvent<HTMLInputElement>) => void;
+}
+
+const CreateRouteForm: React.FC<CreateRouteFormProps> = (props: CreateRouteFormProps) => {
+  const {
+    onInputChange,
+    name,
+    hostname,
+    path,
+    loadedServices,
+    serviceOptions,
+    portOptions,
+    service,
+    targetPort,
+    onTargetPortChange,
+    createRouteOption,
+    onServiceChange,
+    createRoute,
+    onCreateRouteChange,
+    hostnameErrorMsg,
+    pathErrorMsg,
+  } = props;
+
+  return (
+    <React.Fragment>
+      {createRouteOption && (
+        <React.Fragment>
+          <h2>Routing</h2>
+          <FormGroup className="checkbox">
+            <CheckBox
+              onChange={onCreateRouteChange}
+              checked={createRoute}
+              id="createRoute"
+              name="createRoute"
+            >
+              Create a route to the application
+            </CheckBox>
+          </FormGroup>
+        </React.Fragment>
+      )}
+      {(!createRouteOption || createRoute) && (
+        <FormGroup>
+          <div className="co-m-pane__form">
+            {name !== undefined && (
+              <FormGroup controlId="name">
+                <ControlLabel className="co-required">Name</ControlLabel>
+                <FormControl
+                  type="text"
+                  onChange={onInputChange}
+                  value={name}
+                  placeholder="my-route"
+                  name="name"
+                  aria-describedby="name-help"
+                  required
+                />
+                <HelpBlock id="name-help">
+                  Public hostname for the route. If not specified, a hostname is generated.
+                </HelpBlock>
+              </FormGroup>
+            )}
+            {hostname !== undefined && (
+              <FormGroup controlId="hostname">
+                <ControlLabel>Hostname</ControlLabel>
+                <FormControl
+                  type="text"
+                  onChange={onInputChange}
+                  value={hostname}
+                  placeholder="www.example.com"
+                  name="hostname"
+                  aria-describedby="hostname-help"
+                />
+                <HelpBlock id="hostname-help">
+                  Public hostname for the route. If not specified, a hostname is generated.
+                </HelpBlock>
+                {hostnameErrorMsg && (
+                  <div className="has-error">
+                    <HelpBlock>{hostnameErrorMsg}</HelpBlock>
+                  </div>
+                )}
+              </FormGroup>
+            )}
+            {path !== undefined && (
+              <FormGroup controlId="path">
+                <ControlLabel>Path</ControlLabel>
+                <FormControl
+                  type="text"
+                  onChange={onInputChange}
+                  value={path}
+                  placeholder="/"
+                  name="path"
+                  aria-describedby="path-help"
+                />
+                <HelpBlock id="path-help">
+                  Path that the router watches to route traffic to the service.
+                </HelpBlock>
+                {pathErrorMsg && (
+                  <div className="has-error">
+                    <HelpBlock>{pathErrorMsg}</HelpBlock>
+                  </div>
+                )}
+              </FormGroup>
+            )}
+            {loadedServices && (
+              <FormGroup controlId="service">
+                <ControlLabel className="co-required">Service</ControlLabel>
+                {_.isEmpty(serviceOptions) && (
+                  <p className="alert alert-info co-create-route__alert">
+                    <span className="pficon pficon-info" aria-hidden="true" /> There are no services
+                    in your project to expose with a route.
+                  </p>
+                )}
+                {!_.isEmpty(serviceOptions) && (
+                  <Dropdown
+                    items={serviceOptions}
+                    title={service ? serviceOptions[service.metadata.name] : 'Select a service'}
+                    dropDownClassName="dropdown--full-width"
+                    onChange={onServiceChange}
+                    describedBy="service-help"
+                  />
+                )}
+                <HelpBlock id="service-help">Service to route to.</HelpBlock>
+              </FormGroup>
+            )}
+            {targetPort !== undefined && (
+              <FormGroup contolId="target-port">
+                <ControlLabel className="co-required">Target Port</ControlLabel>
+                {_.isEmpty(portOptions) && <p>Select a service above</p>}
+                {!_.isEmpty(portOptions) && (
+                  <Dropdown
+                    items={portOptions}
+                    title={portOptions[targetPort] || 'Select target port'}
+                    dropDownClassName="dropdown--full-width"
+                    onChange={onTargetPortChange}
+                    describedBy="target-port-help"
+                  />
+                )}
+                <HelpBlock id="target-port-help">Target port for traffic.</HelpBlock>
+              </FormGroup>
+            )}
+          </div>
+        </FormGroup>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default CreateRouteForm;

--- a/frontend/public/extend/devconsole/shared/components/SecureRouteForm.tsx
+++ b/frontend/public/extend/devconsole/shared/components/SecureRouteForm.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { FormGroup, ControlLabel, HelpBlock, CheckBox } from 'patternfly-react';
+import { AsyncComponent, Dropdown } from '../../../../components/utils';
+
+const DroppableFileInput = (props) => (
+  <AsyncComponent
+    loader={() =>
+      import('../../../../components/utils/file-input').then((c) => c.DroppableFileInput)
+    }
+    {...props}
+  />
+);
+
+interface SecureRouteFormProps {
+  termination?: string;
+  certificate?: string;
+  privateKey?: string;
+  caCertificate?: string;
+  destinationCACertificate?: string;
+  terminationTypes?: {};
+  passthroughInsecureTrafficTypes?: {};
+  insecureTrafficTypes?: {};
+  secure?: boolean;
+  createRoute?: boolean;
+  createRouteOption?: boolean;
+  onInsecureTrafficChange?: (selectedKey: string) => void;
+  onCertificateChange?: (selectedKey: string) => void;
+  onCaCertificateChange?: (selectedKey: string) => void;
+  onDestinationCACertificateChange?: (selectedKey: string) => void;
+  onPrivateKeyChange?: (selectedKey: string) => void;
+  onSecureRouteChange?: (event: React.SyntheticEvent<HTMLInputElement>) => void;
+  onTerminationChange?: (selectedKey: string) => void;
+}
+
+const SecureRouteForm: React.FC<SecureRouteFormProps> = (props: SecureRouteFormProps) => {
+  const {
+    termination,
+    certificate,
+    privateKey,
+    caCertificate,
+    destinationCACertificate,
+    terminationTypes,
+    onTerminationChange,
+    passthroughInsecureTrafficTypes,
+    insecureTrafficTypes,
+    onInsecureTrafficChange,
+    onCertificateChange,
+    onCaCertificateChange,
+    onDestinationCACertificateChange,
+    onPrivateKeyChange,
+    onSecureRouteChange,
+    secure,
+    createRoute,
+    createRouteOption,
+  } = props;
+  return (
+    <FormGroup>
+      {(!createRouteOption || createRoute) && (
+        <React.Fragment>
+          <ControlLabel>Security</ControlLabel>
+          <FormGroup controlId="secure" className="checkbox">
+            <CheckBox
+              onChange={onSecureRouteChange}
+              checked={secure}
+              name="secure"
+              aria-describedby="secure-help"
+            >
+              Secure route
+            </CheckBox>
+            <HelpBlock id="secure-help">
+              Routes can be secured using several TLS termination types for serving certificates.
+            </HelpBlock>
+          </FormGroup>
+        </React.Fragment>
+      )}
+      {secure && (
+        <div className="co-create-route__security">
+          <FormGroup controlId="tls-termination">
+            <ControlLabel className="co-required">TLS Termination</ControlLabel>
+            <Dropdown
+              items={terminationTypes}
+              title="Select termination type"
+              dropDownClassName="dropdown--full-width"
+              onChange={onTerminationChange}
+            />
+          </FormGroup>
+          <FormGroup
+            controlId="insecure-traffic"
+            className="form-group co-create-route__insecure-traffic"
+          >
+            <ControlLabel>Insecure Traffic</ControlLabel>
+            <Dropdown
+              items={
+                termination === 'passthrough'
+                  ? passthroughInsecureTrafficTypes
+                  : insecureTrafficTypes
+              }
+              title="Select insecure traffic type"
+              dropDownClassName="dropdown--full-width"
+              onChange={onInsecureTrafficChange}
+              describedBy="insecure-traffic-help"
+            />
+            <HelpBlock id="insecure-traffic-help">
+              Policy for traffic on insecure schemes like HTTP.
+            </HelpBlock>
+          </FormGroup>
+          {termination &&
+            termination !== 'passthrough' && (
+            <React.Fragment>
+              <h3>Certificates</h3>
+              <HelpBlock>
+                  TLS certificates for edge and re-encrypt termination. If not specified, the
+                  router's default certificate is used.
+              </HelpBlock>
+              <FormGroup controlId="certificate">
+                <DroppableFileInput
+                  onChange={onCertificateChange}
+                  inputFileData={certificate}
+                  label="Certificate"
+                  inputFieldHelpText="The PEM format certificate. Upload file by dragging &amp; dropping, selecting it, or pasting from the clipboard."
+                />
+              </FormGroup>
+              <FormGroup>
+                <DroppableFileInput
+                  onChange={onPrivateKeyChange}
+                  inputFileData={privateKey}
+                  id="private-key"
+                  label="Private Key"
+                  inputFieldHelpText="The PEM format key. Upload file by dragging &amp; dropping, selecting it, or pasting from the clipboard."
+                />
+              </FormGroup>
+              <FormGroup controlId="ca-certificate">
+                <DroppableFileInput
+                  onChange={onCaCertificateChange}
+                  inputFileData={caCertificate}
+                  label="CA Certificate"
+                  inputFieldHelpText="The PEM format CA certificate chain. Upload file by dragging &amp; dropping, selecting it, or pasting from the clipboard."
+                />
+              </FormGroup>
+              {termination === 'reencrypt' && (
+                <FormGroup controlId="destination-ca-certificate">
+                  <DroppableFileInput
+                    onChange={onDestinationCACertificateChange}
+                    inputFileData={destinationCACertificate}
+                    label="Destination CA Certificate"
+                    inputFieldHelpText="The PEM format CA certificate chain to validate the endpoint certificate for re-encrypt termination. Upload file by dragging &amp; dropping, selecting it, or pasting from the clipboard."
+                  />
+                </FormGroup>
+              )}
+            </React.Fragment>
+          )}
+        </div>
+      )}
+    </FormGroup>
+  );
+};
+
+export default SecureRouteForm;

--- a/frontend/public/extend/devconsole/shared/utils/__tests__/create-route-utils.spec.ts
+++ b/frontend/public/extend/devconsole/shared/utils/__tests__/create-route-utils.spec.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-unused-vars, no-undef */
+import {
+  hostNameErrorMessages,
+  pathErrorMessages,
+  validateHostName,
+  validatePath,
+} from '../create-route-utils';
+
+describe('create-route-utils', () => {
+  it('should validate the hostname', () => {
+    let hostname = 'host_name';
+    let errorMsg = validateHostName(hostname);
+    expect(errorMsg).toBe(hostNameErrorMessages.pattern);
+    hostname = 'host-name';
+    errorMsg = validateHostName(hostname);
+    expect(errorMsg).toBe('');
+  });
+
+  it('should validate the path', () => {
+    let path = 'path';
+    let errorMsg = validatePath(path);
+    expect(errorMsg).toBe(pathErrorMessages.pattern);
+    path = '/path';
+    errorMsg = validatePath(path);
+    expect(errorMsg).toBe('');
+  });
+});

--- a/frontend/public/extend/devconsole/shared/utils/create-route-utils.ts
+++ b/frontend/public/extend/devconsole/shared/utils/create-route-utils.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-unused-vars, no-undef */
+const hostNameValidationParams = {
+  pattern: /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/,
+  maxLength: 253,
+};
+
+const pathValidationParams = {
+  pattern: /^\/.*$/,
+};
+
+export const hostNameErrorMessages = {
+  pattern:
+    'Hostname must consist of lower-case letters, numbers, periods, and hyphens. It must start and end with a letter or number.',
+  maxLength: `Can't be longer than ${hostNameValidationParams.maxLength} characters.`,
+};
+
+export const pathErrorMessages = {
+  pattern: 'Path must start with /',
+};
+
+export const validateHostName = (hostname: string): string => {
+  if (hostname) {
+    if (!hostNameValidationParams.pattern.test(hostname)) {
+      return hostNameErrorMessages.pattern;
+    } else if (hostname.length > hostNameValidationParams.maxLength) {
+      return hostNameErrorMessages.maxLength;
+    }
+  }
+  return '';
+};
+
+export const validatePath = (path: string): string => {
+  if (path && !pathValidationParams.pattern.test(path)) {
+    return pathErrorMessages.pattern;
+  }
+  return '';
+};


### PR DESCRIPTION
Story: https://jira.coreos.com/browse/ODC-818

This PR adds a reusable create-route form that can be integrated across all create flows. Currently only path and host-name are being validated as a part of basic validations and later on the entire `ImportFromGit` form will be validated by doing a dry run on everything first and if there are any errors present, those errors will be shown. 
For reference see https://coreos.slack.com/archives/C6A3NV5J9/p1559577335051200 