### PR TITLE
add deployment config option component

### DIFF
--- a/frontend/public/extend/devconsole/components/deployment-config/DeploymentConfig.tsx
+++ b/frontend/public/extend/devconsole/components/deployment-config/DeploymentConfig.tsx
@@ -1,21 +1,32 @@
 /*eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
-import { Checkbox } from './../../../../../public/components/checkbox';
+import * as _ from 'lodash-es';
+import { Checkbox } from 'patternfly-react';
 import { EnvironmentPage } from './../../../../components/environment';
+import { K8sResourceKind } from './../../../../module/k8s';
 
 interface NameValueType {
   name: string;
   value: string;
 }
 
+interface secretKeyRefType {
+  secretKeyRef: {
+    key: string;
+    name: string;
+  }
+}
+
+interface configMapKeyType {
+  configMapKeyRef: {
+    key: string;
+    name: string
+  }
+}
+
 interface NameValueFormType {
   name: string;
-  valueForm: {
-    configMapKeyRef: {
-      key: string;
-      name: string
-    }
-  }
+  valueForm: configMapKeyType | secretKeyRefType;
 }
 
 interface DeploymentConfigProps {
@@ -25,6 +36,8 @@ interface DeploymentConfigProps {
   newImageAvailableChecked: boolean;
   deploymentConfigChecked: boolean;
   namespace: string;
+  deploymentConfig?: K8sResourceKind;
+  readonly: boolean;
 }
 
 const DeploymentConfig: React.FC<DeploymentConfigProps> = ({onNewImageAvailableChange,
@@ -32,13 +45,16 @@ const DeploymentConfig: React.FC<DeploymentConfigProps> = ({onNewImageAvailableC
   onEnviromentVariableChange,
   newImageAvailableChecked,
   deploymentConfigChecked,
-  namespace}) => {
+  namespace,
+  deploymentConfig = {},
+  readonly,
+}) => {
 
-  const buildConfigObj = {
+  const DeploymentConfigObj = _.isEmpty(deploymentConfig) ? {
     metadata: {
       namespace,
     },
-  };
+  } : deploymentConfig;
 
   return (
     <React.Fragment>
@@ -50,16 +66,18 @@ const DeploymentConfig: React.FC<DeploymentConfigProps> = ({onNewImageAvailableC
       </div>
 
       <Checkbox
-        label="New image is available"
         name="newImageAvailable"
         onChange={onNewImageAvailableChange}
-        checked={newImageAvailableChecked} />
+        checked={newImageAvailableChecked}>
+        New image is available
+      </Checkbox>
 
       <Checkbox
-        label="Deployment configuration changes"
         name="deploymentConfigurationChange"
         onChange={onDeploymentConfigChange}
-        checked={deploymentConfigChecked} />
+        checked={deploymentConfigChecked}>
+        Deployment configuration changes
+      </Checkbox>
 
       <div>
         <div className="co-section-heading-tertiary">
@@ -67,9 +85,9 @@ const DeploymentConfig: React.FC<DeploymentConfigProps> = ({onNewImageAvailableC
         </div>
         <div>
           <EnvironmentPage
-            obj={buildConfigObj}
+            obj={DeploymentConfigObj}
             envPath={['spec','template','spec','containers']}
-            readOnly={false}
+            readOnly={readonly}
             onChange={onEnviromentVariableChange}
             addConfigMapSecret={true}
             useLoadingInline={true} />

--- a/frontend/public/extend/devconsole/components/deployment-config/DeploymentConfig.tsx
+++ b/frontend/public/extend/devconsole/components/deployment-config/DeploymentConfig.tsx
@@ -1,0 +1,81 @@
+/*eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import { Checkbox } from './../../../../../public/components/checkbox';
+import { EnvironmentPage } from './../../../../../public/components/environment';
+
+interface NameValueType {
+  name: string;
+  value: string;
+}
+
+interface NameValueFormType {
+  name: string;
+  valueForm: {
+    configMapKeyRef: {
+      key: string;
+      name: string
+    }
+  }
+}
+
+interface BuildConfigProps {
+  onNewImageAvailableChange: React.ReactEventHandler<HTMLInputElement>;
+  onDeploymentConfigChange: React.ReactEventHandler<HTMLInputElement>;
+  onEnviromentVariableChange: (obj: NameValueType | NameValueFormType) => void;
+  newImageAvailableChecked: boolean;
+  deploymentConfigChecked: boolean;
+  namespace: string;
+}
+
+const DeploymentConfig: React.FC<BuildConfigProps> = ({onNewImageAvailableChange,
+  onDeploymentConfigChange,
+  onEnviromentVariableChange,
+  newImageAvailableChecked,
+  deploymentConfigChecked,
+  namespace}) => {
+
+  const buildConfigObj = {
+    metadata: {
+      namespace: namespace
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <div className="co-section-heading">
+        Deployment Configuration
+      </div>
+      <div className="co-section-heading-tertiary">
+        Autodeploy when
+      </div>
+
+      <Checkbox
+        label="New image is available"
+        name="newImageAvailable"
+        onChange={onNewImageAvailableChange}
+        checked={newImageAvailableChecked} />
+
+      <Checkbox
+        label="Deployment configuration changes"
+        name="deploymentConfigurationChange"
+        onChange={onDeploymentConfigChange}
+        checked={deploymentConfigChecked} />
+
+      <div>
+        <div className="co-section-heading-tertiary">
+          Enviroment Variables (Build and Runtime)
+        </div>
+        <div>
+          <EnvironmentPage
+            obj={buildConfigObj}
+            envPath={['spec','template','spec','containers']}
+            readOnly={false}
+            onChange={onEnviromentVariableChange}
+            addConfigMapSecret={true}
+            useLoadingInline={true} />
+        </div>
+      </div>
+    </React.Fragment>);
+};
+
+export default DeploymentConfig;

--- a/frontend/public/extend/devconsole/components/deployment-config/DeploymentConfig.tsx
+++ b/frontend/public/extend/devconsole/components/deployment-config/DeploymentConfig.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import { Checkbox } from './../../../../../public/components/checkbox';
-import { EnvironmentPage } from './../../../../../public/components/environment';
+import { EnvironmentPage } from './../../../../components/environment';
 
 interface NameValueType {
   name: string;
@@ -18,16 +18,16 @@ interface NameValueFormType {
   }
 }
 
-interface BuildConfigProps {
+interface DeploymentConfigProps {
   onNewImageAvailableChange: React.ReactEventHandler<HTMLInputElement>;
   onDeploymentConfigChange: React.ReactEventHandler<HTMLInputElement>;
-  onEnviromentVariableChange: (obj: NameValueType | NameValueFormType) => void;
+  onEnviromentVariableChange: (envPairs: (NameValueType | NameValueFormType)[]) => void;
   newImageAvailableChecked: boolean;
   deploymentConfigChecked: boolean;
   namespace: string;
 }
 
-const DeploymentConfig: React.FC<BuildConfigProps> = ({onNewImageAvailableChange,
+const DeploymentConfig: React.FC<DeploymentConfigProps> = ({onNewImageAvailableChange,
   onDeploymentConfigChange,
   onEnviromentVariableChange,
   newImageAvailableChecked,
@@ -36,8 +36,8 @@ const DeploymentConfig: React.FC<BuildConfigProps> = ({onNewImageAvailableChange
 
   const buildConfigObj = {
     metadata: {
-      namespace: namespace
-    }
+      namespace,
+    },
   };
 
   return (

--- a/frontend/public/extend/devconsole/shared/components/advanced-options/DeploymentConfig.tsx
+++ b/frontend/public/extend/devconsole/shared/components/advanced-options/DeploymentConfig.tsx
@@ -2,8 +2,8 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Checkbox } from 'patternfly-react';
-import { EnvironmentPage } from './../../../../components/environment';
-import { K8sResourceKind } from './../../../../module/k8s';
+import { EnvironmentPage } from '../../../../../components/environment';
+import { K8sResourceKind } from '../../../../../module/k8s';
 
 interface NameValueType {
   name: string;


### PR DESCRIPTION
Story: - https://jira.coreos.com/browse/ODC-820

This change adds deployment configuration pure component.

```Typescript
<DeploymentConfig
            onNewImageAvailableChange={this.onConfigureWebhookChange}
            onDeploymentConfigChange={this.onLaunchFirstBuildChange}
            onEnviromentVariableChange={this.onEnviromentVariableChange}
            newImageAvailableChecked={this.state.configureWebhookChecked}
            deploymentConfigChecked={this.state.automaticallyBuildChecked}
            namespace={this.state.namespace}
            deploymentConfig={}
          />
```