### PR TITLE
feat(advanced-options): create pure component for resource limits

### DIFF
--- a/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.scss
+++ b/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.scss
@@ -1,7 +1,3 @@
-.odc-resource-limit-row {
-  display: flex;
-}
-
-.odc-resource-limit-unit {
-  padding-left: 5%;
+.col-sm-2 {
+  width: auto;
 }

--- a/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.scss
+++ b/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.scss
@@ -1,0 +1,7 @@
+.odc-resource-limit-row {
+  display: flex;
+}
+
+.odc-resource-limit-unit {
+  padding-left: 5%;
+}

--- a/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.scss
+++ b/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.scss
@@ -1,3 +1,0 @@
-.col-sm-2 {
-  width: auto;
-}

--- a/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.tsx
+++ b/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.tsx
@@ -37,10 +37,9 @@ export const isPositive = (value: number) => {
   return value >= 0 ? '' : 'Can\'t be negative.';
 };
 
-export const convertValueToBase = (value, unitLabel) => {
+export const convertValueToBase = (value: number, unitLabel: string) => {
   let val: number;
   switch (unitLabel) {
-    //millicores
     case 'millicores':
       val = convertToBaseValue(`${value} m`);
       break;
@@ -63,8 +62,8 @@ export const convertValueToBase = (value, unitLabel) => {
   return val;
 };
 
-export const validateLimit = (min, max, unitOfMin, unitOfMax) => {
-  if (isPositive(max) !== '') {
+export const validateLimit = (min: number, max: number, unitOfMin: string, unitOfMax: string) => {
+  if (isPositive(max)) {
     return isPositive(max);
   }
   const minInBase = convertValueToBase(min, unitOfMin);
@@ -105,10 +104,10 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
     memory: memoryUnits.MiB,
   };
 
-  const firstLabel = 'MiB';
-  const secondLabel = 'MB';
+  const binaryUnitLabel = 'MiB';
+  const decimalUnitLabel = 'MB';
 
-  const onChangeCpuRequestData: React.ReactEventHandler<HTMLInputElement> = (event) => {
+  const onChangeCpuRequestData: React.ReactEventHandler<HTMLInputElement> = (event: React.SyntheticEvent<HTMLInputElement>) => {
     const val = event.currentTarget.value === '' ? 0 : event.currentTarget.valueAsNumber;
     onCpuRequestChange({
       [event.currentTarget.name]: val,
@@ -116,7 +115,7 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
     });
   };
 
-  const onChangeCpuLimitData: React.ReactEventHandler<HTMLInputElement> = (event) => {
+  const onChangeCpuLimitData: React.ReactEventHandler<HTMLInputElement> = (event: React.SyntheticEvent<HTMLInputElement>) => {
     const val = event.currentTarget.value === '' ? 0 : event.currentTarget.valueAsNumber;
     onCpuLimitChange({
       [event.currentTarget.name]: val,
@@ -124,7 +123,7 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
     });
   };
 
-  const onChangeMemoryRequestData: React.ReactEventHandler<HTMLInputElement> = (event) => {
+  const onChangeMemoryRequestData: React.ReactEventHandler<HTMLInputElement> = (event: React.SyntheticEvent<HTMLInputElement>) => {
     const val = event.currentTarget.value === '' ? 0 : event.currentTarget.valueAsNumber;
     onMemoryRequestChange({
       [event.currentTarget.name]: val,
@@ -132,7 +131,7 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
     });
   };
 
-  const onChangeMemoryLimitData: React.ReactEventHandler<HTMLInputElement> = (event) => {
+  const onChangeMemoryLimitData: React.ReactEventHandler<HTMLInputElement> = (event: React.SyntheticEvent<HTMLInputElement>) => {
     const val = event.currentTarget.value === '' ? 0 : event.currentTarget.valueAsNumber;
     onMemoryLimitChange({
       [event.currentTarget.name]: val,
@@ -140,56 +139,56 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
     });
   };
 
-  const onChangeCpuRequest = (operation) => {
+  const onChangeCpuRequest = (operation : number) => {
     onCpuRequestChange({
       ['request']: _.toInteger(cpuRequest.request) + operation,
       ['requestUnit']: cpuRequest.requestUnit || defaultUnit.cpu,
     });
   };
 
-  const onCpuRequestUnitChange = (val) => {
+  const onCpuRequestUnitChange = (val: string) => {
     onCpuRequestChange({
       ['request']: cpuRequest.request,
       ['requestUnit']: cpuUnits[val],
     });
   };
 
-  const onChangeCpuLimit = (operation) => {
+  const onChangeCpuLimit = (operation: number) => {
     onCpuLimitChange({
       ['limit']: _.toInteger(cpuLimit.limit) + operation,
       ['limitUnit']: cpuLimit.limitUnit || defaultUnit.cpu,
     });
   };
 
-  const onCpuLimitUnitChange = (val) => {
+  const onCpuLimitUnitChange = (val: string) => {
     onCpuLimitChange({
       ['limit']: cpuLimit.limit,
       ['limitUnit']: cpuUnits[val],
     });
   };
 
-  const onChangeMemoryRequest = (operation) => {
+  const onChangeMemoryRequest = (operation: number) => {
     onMemoryRequestChange({
       ['request']: _.toInteger(memoryRequest.request) + operation,
       ['requestUnit']: memoryRequest.requestUnit || defaultUnit.memory,
     });
   };
 
-  const onMemoryRequestUnitChange = (val) => {
+  const onMemoryRequestUnitChange = (val: string) => {
     onMemoryRequestChange({
       ['request']: memoryRequest.request,
       ['requestUnit']: memoryUnits[val],
     });
   };
 
-  const onChangeMemoryLimit = (operation) => {
+  const onChangeMemoryLimit = (operation: number) => {
     onMemoryLimitChange({
       ['limit']: _.toInteger(memoryLimit.limit) + operation,
       ['limitUnit']: memoryLimit.limitUnit || defaultUnit.memory,
     });
   };
 
-  const onMemoryLimitUnitChange = (val) => {
+  const onMemoryLimitUnitChange = (val: string) => {
     onMemoryLimitChange({
       ['limit']: memoryLimit.limit,
       ['limitUnit']: memoryUnits[val],
@@ -200,9 +199,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
     <React.Fragment>
       <div className="co-section-heading">Resource Limits</div>
       <div className="co-section-heading-tertiary">CPU</div>
-      <FormGroup controlId="cpu-request" className={cpuRequestError ? 'has-error' : ''}>
-        <div className="odc-resource-limit-row">
-          <div>
+      <FormGroup controlId="cpu-request" className={cpuRequestError && 'has-error'}>
+        <div className="co-m-table-grid__body row">
+          <div className="col-sm-3">
             <ControlLabel>Request</ControlLabel>
             <NumberSpinner
               id="cpu-request"
@@ -213,10 +212,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
               changeValueBy={onChangeCpuRequest}
             />
           </div>
-          <div className="odc-resource-limit-unit">
+          <div className="col-sm-2">
             <ControlLabel>Unit</ControlLabel>
             <Dropdown
-              // className="odc-resource-limits-dropdown"
               dropDownClassName="dropdown--full-width"
               items={cpuUnits}
               selectedKey={cpuUnits.millicores}
@@ -228,9 +226,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
         <HelpBlock>The minimum amount of CPU the container is guaranteed.</HelpBlock>
         <HelpBlock>{cpuRequestError}</HelpBlock>
       </FormGroup>
-      <FormGroup controlId="cpu-limit" className={cpuLimitError ? 'has-error' : ''}>
-        <div className="odc-resource-limit-row">
-          <div>
+      <FormGroup controlId="cpu-limit" className={cpuLimitError && 'has-error'}>
+        <div className="co-m-table-grid__body row">
+          <div  className="col-sm-3">
             <ControlLabel>Limit</ControlLabel>
             <NumberSpinner
               id="cpu-limit"
@@ -241,10 +239,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
               changeValueBy={onChangeCpuLimit}
             />
           </div>
-          <div className="odc-resource-limit-unit">
+          <div className="col-sm-2">
             <ControlLabel>Unit</ControlLabel>
             <Dropdown
-              // className="odc-resource-limits-dropdown"
               dropDownClassName="dropdown--full-width"
               items={cpuUnits}
               selectedKey={cpuUnits.millicores}
@@ -259,9 +256,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
         <HelpBlock>{cpuLimitError}</HelpBlock>
       </FormGroup>
       <div className="co-section-heading-tertiary">Memory</div>
-      <FormGroup controlId="memory-request" className={memoryRequestError ? 'has-error' : ''}>
-        <div className="odc-resource-limit-row">
-          <div>
+      <FormGroup controlId="memory-request" className={memoryRequestError && 'has-error'}>
+        <div className="co-m-table-grid__body row">
+          <div className="col-sm-3">
             <ControlLabel>Request</ControlLabel>
             <NumberSpinner
               id="memory-request"
@@ -272,18 +269,17 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
               changeValueBy={onChangeMemoryRequest}
             />
           </div>
-          <div className="odc-resource-limit-unit">
+          <div className="col-sm-2">
             <ControlLabel>Unit</ControlLabel>
             <Dropdown
-              // className="odc-resource-limits-dropdown"
               dropDownClassName="dropdown--full-width"
               items={memoryUnits}
               selectedKey={memoryUnits.MiB}
               title={memoryUnits.MiB}
-              spacerBefore={new Set([secondLabel])}
+              spacerBefore={new Set([decimalUnitLabel])}
               headerBefore={{
-                [firstLabel]: 'Binary Units',
-                [secondLabel]: 'Decimal Units',
+                [binaryUnitLabel]: 'Binary Units',
+                [decimalUnitLabel]: 'Decimal Units',
               }}
               onChange={onMemoryRequestUnitChange}
             />
@@ -292,9 +288,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
         <HelpBlock>The minimum amount of Memory the container is guaranteed.</HelpBlock>
         <HelpBlock>{memoryRequestError}</HelpBlock>
       </FormGroup>
-      <FormGroup controlId="memory-limit" className={memoryLimitError ? 'has-error' : ''}>
-        <div className="odc-resource-limit-row">
-          <div>
+      <FormGroup controlId="memory-limit" className={memoryLimitError && 'has-error'}>
+        <div className="co-m-table-grid__body row">
+          <div className="col-sm-3">
             <ControlLabel>Limit</ControlLabel>
             <NumberSpinner
               id="memory-limit"
@@ -305,18 +301,17 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
               changeValueBy={onChangeMemoryLimit}
             />
           </div>
-          <div className="odc-resource-limit-unit">
+          <div className="col-sm-2">
             <ControlLabel>Unit</ControlLabel>
             <Dropdown
-              // className="odc-resource-limits-dropdown"
               dropDownClassName="dropdown--full-width"
               items={memoryUnits}
               selectedKey={memoryUnits.MiB}
               title={memoryUnits.MiB}
-              spacerBefore={new Set([secondLabel])}
+              spacerBefore={new Set([decimalUnitLabel])}
               headerBefore={{
-                [firstLabel]: 'Binary Units',
-                [secondLabel]: 'Decimal Units',
+                [binaryUnitLabel]: 'Binary Units',
+                [decimalUnitLabel]: 'Decimal Units',
               }}
               onChange={onMemoryLimitUnitChange}
             />

--- a/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.tsx
+++ b/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.tsx
@@ -1,0 +1,334 @@
+/* eslint-disable no-undef, dot-notation */
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import { FormGroup, ControlLabel, HelpBlock } from 'patternfly-react';
+import {
+  NumberSpinner,
+  Dropdown,
+  units,
+  convertToBaseValue,
+} from '../../../../../components/utils';
+import './ResourceLimits.scss';
+
+interface ResourceLimitProps {
+  cpuRequest?: {
+    [key: string]: string | number;
+  };
+  cpuLimit?: {
+    [key: string]: string | number;
+  };
+  memoryRequest?: {
+    [key: string]: string | number;
+  };
+  memoryLimit?: {
+    [key: string]: string | number;
+  };
+  cpuRequestError?: string;
+  cpuLimitError?: string;
+  memoryRequestError?: string;
+  memoryLimitError?: string;
+  onCpuRequestChange?: (cpuRequest?: { [key: string]: string | number }) => void;
+  onCpuLimitChange?: (cpuLimit?: { [key: string]: string | number }) => void;
+  onMemoryRequestChange?: (memoryRequest?: { [key: string]: string | number }) => void;
+  onMemoryLimitChange?: (memoryLimit?: { [key: string]: string | number }) => void;
+}
+
+export const isPositive = (value: number) => {
+  return value >= 0 ? '' : 'Can\'t be negative.';
+};
+
+export const convertValueToBase = (value, unitLabel) => {
+  let val: number;
+  switch (unitLabel) {
+    //millicores
+    case 'millicores':
+      val = convertToBaseValue(`${value} m`);
+      break;
+    case 'MiB':
+      val = units.dehumanize(`${value}MiB`, 'binaryBytes').value;
+      break;
+    case 'GiB':
+      val = units.dehumanize(`${value}GiB`, 'binaryBytes').value;
+      break;
+    case 'MB':
+      val = units.dehumanize(`${value}MB`, 'decimalBytes').value;
+      break;
+    case 'GB':
+      val = units.dehumanize(`${value}GB`, 'decimalBytes').value;
+      break;
+    default:
+      val = value;
+      break;
+  }
+  return val;
+};
+
+export const validateLimit = (min, max, unitOfMin, unitOfMax) => {
+  if (isPositive(max) !== '') {
+    return isPositive(max);
+  }
+  const minInBase = convertValueToBase(min, unitOfMin);
+  const maxInBase = convertValueToBase(max, unitOfMax);
+  if (maxInBase < minInBase) {
+    return `Limit can't be less than request (${min} ${unitOfMin}).`;
+  }
+};
+
+const ResourceLimits: React.FC<ResourceLimitProps> = ({
+  cpuRequest,
+  cpuLimit,
+  memoryRequest,
+  memoryLimit,
+  cpuRequestError,
+  cpuLimitError,
+  memoryRequestError,
+  memoryLimitError,
+  onCpuRequestChange,
+  onCpuLimitChange,
+  onMemoryRequestChange,
+  onMemoryLimitChange,
+}) => {
+  const cpuUnits: { [key: string]: string } = {
+    millicores: 'millicores',
+    cores: 'cores',
+  };
+
+  const memoryUnits: { [key: string]: string } = {
+    MiB: 'MiB',
+    GiB: 'GiB',
+    MB: 'MB',
+    GB: 'GB',
+  };
+
+  const defaultUnit: { [key: string]: string } = {
+    cpu: cpuUnits.millicores,
+    memory: memoryUnits.MiB,
+  };
+
+  const firstLabel = 'MiB';
+  const secondLabel = 'MB';
+
+  const onChangeCpuRequestData: React.ReactEventHandler<HTMLInputElement> = (event) => {
+    const val = event.currentTarget.value === '' ? 0 : event.currentTarget.valueAsNumber;
+    onCpuRequestChange({
+      [event.currentTarget.name]: val,
+      ['requestUnit']: cpuRequest.requestUnit || defaultUnit.cpu,
+    });
+  };
+
+  const onChangeCpuLimitData: React.ReactEventHandler<HTMLInputElement> = (event) => {
+    const val = event.currentTarget.value === '' ? 0 : event.currentTarget.valueAsNumber;
+    onCpuLimitChange({
+      [event.currentTarget.name]: val,
+      ['limitUnit']: cpuLimit.limitUnit || defaultUnit.cpu,
+    });
+  };
+
+  const onChangeMemoryRequestData: React.ReactEventHandler<HTMLInputElement> = (event) => {
+    const val = event.currentTarget.value === '' ? 0 : event.currentTarget.valueAsNumber;
+    onMemoryRequestChange({
+      [event.currentTarget.name]: val,
+      ['requestUnit']: memoryRequest.requestUnit || defaultUnit.memory,
+    });
+  };
+
+  const onChangeMemoryLimitData: React.ReactEventHandler<HTMLInputElement> = (event) => {
+    const val = event.currentTarget.value === '' ? 0 : event.currentTarget.valueAsNumber;
+    onMemoryLimitChange({
+      [event.currentTarget.name]: val,
+      ['limitUnit']: memoryLimit.limitUnit || defaultUnit.memory,
+    });
+  };
+
+  const onChangeCpuRequest = (operation) => {
+    onCpuRequestChange({
+      ['request']: _.toInteger(cpuRequest.request) + operation,
+      ['requestUnit']: cpuRequest.requestUnit || defaultUnit.cpu,
+    });
+  };
+
+  const onCpuRequestUnitChange = (val) => {
+    onCpuRequestChange({
+      ['request']: cpuRequest.request,
+      ['requestUnit']: cpuUnits[val],
+    });
+  };
+
+  const onChangeCpuLimit = (operation) => {
+    onCpuLimitChange({
+      ['limit']: _.toInteger(cpuLimit.limit) + operation,
+      ['limitUnit']: cpuLimit.limitUnit || defaultUnit.cpu,
+    });
+  };
+
+  const onCpuLimitUnitChange = (val) => {
+    onCpuLimitChange({
+      ['limit']: cpuLimit.limit,
+      ['limitUnit']: cpuUnits[val],
+    });
+  };
+
+  const onChangeMemoryRequest = (operation) => {
+    onMemoryRequestChange({
+      ['request']: _.toInteger(memoryRequest.request) + operation,
+      ['requestUnit']: memoryRequest.requestUnit || defaultUnit.memory,
+    });
+  };
+
+  const onMemoryRequestUnitChange = (val) => {
+    onMemoryRequestChange({
+      ['request']: memoryRequest.request,
+      ['requestUnit']: memoryUnits[val],
+    });
+  };
+
+  const onChangeMemoryLimit = (operation) => {
+    onMemoryLimitChange({
+      ['limit']: _.toInteger(memoryLimit.limit) + operation,
+      ['limitUnit']: memoryLimit.limitUnit || defaultUnit.memory,
+    });
+  };
+
+  const onMemoryLimitUnitChange = (val) => {
+    onMemoryLimitChange({
+      ['limit']: memoryLimit.limit,
+      ['limitUnit']: memoryUnits[val],
+    });
+  };
+
+  return (
+    <React.Fragment>
+      <div className="co-section-heading">Resource Limits</div>
+      <div className="co-section-heading-tertiary">CPU</div>
+      <FormGroup controlId="cpu-request" className={cpuRequestError ? 'has-error' : ''}>
+        <div className="odc-resource-limit-row">
+          <div>
+            <ControlLabel>Request</ControlLabel>
+            <NumberSpinner
+              id="cpu-request"
+              name="request"
+              className="form-control"
+              value={cpuRequest.request}
+              onChange={onChangeCpuRequestData}
+              changeValueBy={onChangeCpuRequest}
+            />
+          </div>
+          <div className="odc-resource-limit-unit">
+            <ControlLabel>Unit</ControlLabel>
+            <Dropdown
+              // className="odc-resource-limits-dropdown"
+              dropDownClassName="dropdown--full-width"
+              items={cpuUnits}
+              selectedKey={cpuUnits.millicores}
+              title={cpuUnits.millicores}
+              onChange={onCpuRequestUnitChange}
+            />
+          </div>
+        </div>
+        <HelpBlock>The minimum amount of CPU the container is guaranteed.</HelpBlock>
+        <HelpBlock>{cpuRequestError}</HelpBlock>
+      </FormGroup>
+      <FormGroup controlId="cpu-limit" className={cpuLimitError ? 'has-error' : ''}>
+        <div className="odc-resource-limit-row">
+          <div>
+            <ControlLabel>Limit</ControlLabel>
+            <NumberSpinner
+              id="cpu-limit"
+              name="limit"
+              className="form-control"
+              value={cpuLimit.limit}
+              onChange={onChangeCpuLimitData}
+              changeValueBy={onChangeCpuLimit}
+            />
+          </div>
+          <div className="odc-resource-limit-unit">
+            <ControlLabel>Unit</ControlLabel>
+            <Dropdown
+              // className="odc-resource-limits-dropdown"
+              dropDownClassName="dropdown--full-width"
+              items={cpuUnits}
+              selectedKey={cpuUnits.millicores}
+              title={cpuUnits.millicores}
+              onChange={onCpuLimitUnitChange}
+            />
+          </div>
+        </div>
+        <HelpBlock>
+          The maximum amount of CPU the container is allowed to use when running.
+        </HelpBlock>
+        <HelpBlock>{cpuLimitError}</HelpBlock>
+      </FormGroup>
+      <div className="co-section-heading-tertiary">Memory</div>
+      <FormGroup controlId="memory-request" className={memoryRequestError ? 'has-error' : ''}>
+        <div className="odc-resource-limit-row">
+          <div>
+            <ControlLabel>Request</ControlLabel>
+            <NumberSpinner
+              id="memory-request"
+              name="request"
+              className="form-control"
+              value={memoryRequest.request}
+              onChange={onChangeMemoryRequestData}
+              changeValueBy={onChangeMemoryRequest}
+            />
+          </div>
+          <div className="odc-resource-limit-unit">
+            <ControlLabel>Unit</ControlLabel>
+            <Dropdown
+              // className="odc-resource-limits-dropdown"
+              dropDownClassName="dropdown--full-width"
+              items={memoryUnits}
+              selectedKey={memoryUnits.MiB}
+              title={memoryUnits.MiB}
+              spacerBefore={new Set([secondLabel])}
+              headerBefore={{
+                [firstLabel]: 'Binary Units',
+                [secondLabel]: 'Decimal Units',
+              }}
+              onChange={onMemoryRequestUnitChange}
+            />
+          </div>
+        </div>
+        <HelpBlock>The minimum amount of Memory the container is guaranteed.</HelpBlock>
+        <HelpBlock>{memoryRequestError}</HelpBlock>
+      </FormGroup>
+      <FormGroup controlId="memory-limit" className={memoryLimitError ? 'has-error' : ''}>
+        <div className="odc-resource-limit-row">
+          <div>
+            <ControlLabel>Limit</ControlLabel>
+            <NumberSpinner
+              id="memory-limit"
+              name="limit"
+              className="form-control"
+              value={memoryLimit.limit}
+              onChange={onChangeMemoryLimitData}
+              changeValueBy={onChangeMemoryLimit}
+            />
+          </div>
+          <div className="odc-resource-limit-unit">
+            <ControlLabel>Unit</ControlLabel>
+            <Dropdown
+              // className="odc-resource-limits-dropdown"
+              dropDownClassName="dropdown--full-width"
+              items={memoryUnits}
+              selectedKey={memoryUnits.MiB}
+              title={memoryUnits.MiB}
+              spacerBefore={new Set([secondLabel])}
+              headerBefore={{
+                [firstLabel]: 'Binary Units',
+                [secondLabel]: 'Decimal Units',
+              }}
+              onChange={onMemoryLimitUnitChange}
+            />
+          </div>
+        </div>
+        <HelpBlock>
+          The maximum amount of Memory the container is allowed to use when running.
+        </HelpBlock>
+        <HelpBlock>{memoryLimitError}</HelpBlock>
+      </FormGroup>
+    </React.Fragment>
+  );
+};
+
+export default ResourceLimits;

--- a/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.tsx
+++ b/frontend/public/extend/devconsole/shared/components/advanced-options/ResourceLimits.tsx
@@ -8,7 +8,6 @@ import {
   units,
   convertToBaseValue,
 } from '../../../../../components/utils';
-import './ResourceLimits.scss';
 
 interface ResourceLimitProps {
   cpuRequest?: {
@@ -200,8 +199,8 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
       <div className="co-section-heading">Resource Limits</div>
       <div className="co-section-heading-tertiary">CPU</div>
       <FormGroup controlId="cpu-request" className={cpuRequestError && 'has-error'}>
-        <div className="co-m-table-grid__body row">
-          <div className="col-sm-3">
+        <div className="row">
+          <div className="col-lg-4 col-md-4 col-xs-7 col-sm-6">
             <ControlLabel>Request</ControlLabel>
             <NumberSpinner
               id="cpu-request"
@@ -212,10 +211,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
               changeValueBy={onChangeCpuRequest}
             />
           </div>
-          <div className="col-sm-2">
+          <div className="col-lg-8 col-md-8 col-xs-5 col-sm-6">
             <ControlLabel>Unit</ControlLabel>
             <Dropdown
-              dropDownClassName="dropdown--full-width"
               items={cpuUnits}
               selectedKey={cpuUnits.millicores}
               title={cpuUnits.millicores}
@@ -224,11 +222,11 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
           </div>
         </div>
         <HelpBlock>The minimum amount of CPU the container is guaranteed.</HelpBlock>
-        <HelpBlock>{cpuRequestError}</HelpBlock>
+        {cpuRequestError && <HelpBlock>{cpuRequestError}</HelpBlock>}
       </FormGroup>
       <FormGroup controlId="cpu-limit" className={cpuLimitError && 'has-error'}>
-        <div className="co-m-table-grid__body row">
-          <div  className="col-sm-3">
+        <div className="row">
+          <div  className="col-lg-4 col-md-4 col-xs-7 col-sm-6">
             <ControlLabel>Limit</ControlLabel>
             <NumberSpinner
               id="cpu-limit"
@@ -239,10 +237,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
               changeValueBy={onChangeCpuLimit}
             />
           </div>
-          <div className="col-sm-2">
+          <div className="col-lg-8 col-md-8 col-xs-5 col-sm-6">
             <ControlLabel>Unit</ControlLabel>
             <Dropdown
-              dropDownClassName="dropdown--full-width"
               items={cpuUnits}
               selectedKey={cpuUnits.millicores}
               title={cpuUnits.millicores}
@@ -253,12 +250,12 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
         <HelpBlock>
           The maximum amount of CPU the container is allowed to use when running.
         </HelpBlock>
-        <HelpBlock>{cpuLimitError}</HelpBlock>
+        {cpuLimitError && <HelpBlock>{cpuLimitError}</HelpBlock>}
       </FormGroup>
       <div className="co-section-heading-tertiary">Memory</div>
       <FormGroup controlId="memory-request" className={memoryRequestError && 'has-error'}>
-        <div className="co-m-table-grid__body row">
-          <div className="col-sm-3">
+        <div className="row">
+          <div className="col-lg-4 col-md-4 col-xs-7 col-sm-6">
             <ControlLabel>Request</ControlLabel>
             <NumberSpinner
               id="memory-request"
@@ -269,10 +266,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
               changeValueBy={onChangeMemoryRequest}
             />
           </div>
-          <div className="col-sm-2">
+          <div className="col-lg-8 col-md-8 col-xs-5 col-sm-6">
             <ControlLabel>Unit</ControlLabel>
             <Dropdown
-              dropDownClassName="dropdown--full-width"
               items={memoryUnits}
               selectedKey={memoryUnits.MiB}
               title={memoryUnits.MiB}
@@ -286,11 +282,11 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
           </div>
         </div>
         <HelpBlock>The minimum amount of Memory the container is guaranteed.</HelpBlock>
-        <HelpBlock>{memoryRequestError}</HelpBlock>
+        {memoryRequestError && <HelpBlock>{memoryRequestError}</HelpBlock>}
       </FormGroup>
       <FormGroup controlId="memory-limit" className={memoryLimitError && 'has-error'}>
-        <div className="co-m-table-grid__body row">
-          <div className="col-sm-3">
+        <div className="row">
+          <div className="col-lg-4 col-md-4 col-xs-7 col-sm-6">
             <ControlLabel>Limit</ControlLabel>
             <NumberSpinner
               id="memory-limit"
@@ -301,10 +297,9 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
               changeValueBy={onChangeMemoryLimit}
             />
           </div>
-          <div className="col-sm-2">
+          <div className="col-lg-8 col-md-8 col-xs-5 col-sm-6">
             <ControlLabel>Unit</ControlLabel>
             <Dropdown
-              dropDownClassName="dropdown--full-width"
               items={memoryUnits}
               selectedKey={memoryUnits.MiB}
               title={memoryUnits.MiB}
@@ -320,7 +315,7 @@ const ResourceLimits: React.FC<ResourceLimitProps> = ({
         <HelpBlock>
           The maximum amount of Memory the container is allowed to use when running.
         </HelpBlock>
-        <HelpBlock>{memoryLimitError}</HelpBlock>
+        {memoryLimitError && <HelpBlock>{memoryLimitError}</HelpBlock>}
       </FormGroup>
     </React.Fragment>
   );


### PR DESCRIPTION
This PR includes:
- A pure component for Advanced Options: Resource Limits
- The Number Spinners displays an error when negative values are entered
- The Number Spinners displays an error when value of `Request` is greater than `Limit`

Refer Story: https://jira.coreos.com/browse/ODC-822

![2019-06-09-14_43_55 639960](https://user-images.githubusercontent.com/22490998/59157429-dc42c880-8ac7-11e9-86ca-bde90561d63d.gif)
