### PR TITLE
Add scaling advanced options to git import form and downgrade formik to 2.0.1-rc.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
     "d3": "^5.9.2",
     "file-saver": "1.3.x",
     "font-awesome": "4.7.x",
-    "formik": "2.0.1-rc.4",
+    "formik": "2.0.1-rc.1",
     "fuzzysearch": "1.0.x",
     "history": "4.x",
     "immutable": "3.x",

--- a/frontend/public/extend/devconsole/components/formik-fields/NumberSpinnerField.tsx
+++ b/frontend/public/extend/devconsole/components/formik-fields/NumberSpinnerField.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import cx from 'classnames';
+import { useField, useFormikContext, FormikValues } from 'formik';
+import { FormGroup, ControlLabel, HelpBlock } from 'patternfly-react';
+import { InputFieldProps } from './field-types';
+import { getValidationState } from './field-utils';
+import { NumberSpinner } from '../../../../components/utils';
+
+const NumberSpinnerField: React.FC<InputFieldProps> = ({ label, helpText, ...props }) => {
+  const [field, { touched, error }] = useField(props.name);
+  const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
+  return (
+    <FormGroup
+      controlId={`${props.name}-field`}
+      validationState={getValidationState(error, touched)}
+    >
+      <ControlLabel className={cx({ 'co-required': props.required })}>{label}</ControlLabel>
+      <NumberSpinner
+        id={`${props.name}-field`}
+        {...field}
+        {...props}
+        changeValueBy={(operation: number) => {
+          setFieldValue(props.name, field.value + operation);
+          setFieldTouched(props.name, true);
+        }}
+        aria-describedby={`${props.name}-help`}
+      />
+      {helpText && <HelpBlock id={`${props.name}-help`}>{helpText}</HelpBlock>}
+      {touched && error && <HelpBlock>{error}</HelpBlock>}
+    </FormGroup>
+  );
+};
+
+export default NumberSpinnerField;

--- a/frontend/public/extend/devconsole/components/formik-fields/NumberSpinnerField.tsx
+++ b/frontend/public/extend/devconsole/components/formik-fields/NumberSpinnerField.tsx
@@ -21,7 +21,7 @@ const NumberSpinnerField: React.FC<InputFieldProps> = ({ label, helpText, ...pro
         {...field}
         {...props}
         changeValueBy={(operation: number) => {
-          setFieldValue(props.name, field.value + operation);
+          setFieldValue(props.name, Number(field.value) + operation);
           setFieldTouched(props.name, true);
         }}
         aria-describedby={`${props.name}-help`}

--- a/frontend/public/extend/devconsole/components/formik-fields/NumberSpinnerField.tsx
+++ b/frontend/public/extend/devconsole/components/formik-fields/NumberSpinnerField.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
+import * as _ from 'lodash-es';
 import cx from 'classnames';
 import { useField, useFormikContext, FormikValues } from 'formik';
 import { FormGroup, ControlLabel, HelpBlock } from 'patternfly-react';
@@ -21,7 +22,7 @@ const NumberSpinnerField: React.FC<InputFieldProps> = ({ label, helpText, ...pro
         {...field}
         {...props}
         changeValueBy={(operation: number) => {
-          setFieldValue(props.name, Number(field.value) + operation);
+          setFieldValue(props.name, _.toInteger(field.value) + operation);
           setFieldTouched(props.name, true);
         }}
         aria-describedby={`${props.name}-help`}

--- a/frontend/public/extend/devconsole/components/formik-fields/index.ts
+++ b/frontend/public/extend/devconsole/components/formik-fields/index.ts
@@ -2,3 +2,4 @@ export { default as InputField } from './InputField';
 export { default as DropdownField } from './DropdownField';
 export { default as NSDropdownField } from './NSDropdownField';
 export { default as CheckboxField } from './CheckboxField';
+export { default as NumberSpinnerField } from './NumberSpinnerField';

--- a/frontend/public/extend/devconsole/components/import/GitImport.tsx
+++ b/frontend/public/extend/devconsole/components/import/GitImport.tsx
@@ -46,6 +46,7 @@ const GitImport: React.FC<GitImportProps> = ({ namespace, imageStreams }) => {
     route: {
       create: true,
     },
+    replicas: 1,
   };
 
   const builderImages: NormalizedBuilderImages =

--- a/frontend/public/extend/devconsole/components/import/GitImportForm.tsx
+++ b/frontend/public/extend/devconsole/components/import/GitImportForm.tsx
@@ -8,6 +8,7 @@ import GitSection from './git/GitSection';
 import BuilderSection from './builder/BuilderSection';
 import AppSection from './app/AppSection';
 import RouteSection from './route/RouteSection';
+import ScalingSection from './scaling/ScalingSection';
 
 export interface GitImportFormProps {
   builderImages?: NormalizedBuilderImages;
@@ -30,6 +31,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
       <BuilderSection image={values.image} builderImages={builderImages} />
       <ExpandCollapse>
         <RouteSection />
+        <ScalingSection />
       </ExpandCollapse>
     </div>
     <br />

--- a/frontend/public/extend/devconsole/components/import/GitImportForm.tsx
+++ b/frontend/public/extend/devconsole/components/import/GitImportForm.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars, no-undef, dot-notation */
 import * as React from 'react';
+import * as _ from 'lodash-es';
 import { Form, Button, ExpandCollapse } from 'patternfly-react';
 import { FormikProps, FormikValues } from 'formik';
 import { ButtonBar } from '../../../../components/utils';
@@ -16,12 +17,12 @@ export interface GitImportFormProps {
 
 const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = ({
   values,
+  errors,
   handleSubmit,
   handleReset,
   builderImages,
   status,
   isSubmitting,
-  isValid,
   dirty,
 }) => (
   <Form onReset={handleReset} onSubmit={handleSubmit}>
@@ -36,7 +37,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
     </div>
     <br />
     <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
-      <Button disabled={!dirty || !isValid} type="submit" bsStyle="primary">
+      <Button disabled={!dirty || !_.isEmpty(errors)} type="submit" bsStyle="primary">
         Create
       </Button>
       <Button type="reset">Cancel</Button>

--- a/frontend/public/extend/devconsole/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/public/extend/devconsole/components/import/__tests__/import-validation-utils.spec.ts
@@ -43,7 +43,8 @@ describe('ValidationUtils', () => {
       },
       route: {
         create: false,
-      }
+      },
+      replicas: 1,
     };
 
     it('should validate the form data', async() => {

--- a/frontend/public/extend/devconsole/components/import/builder/BuilderImageSelector.tsx
+++ b/frontend/public/extend/devconsole/components/import/builder/BuilderImageSelector.tsx
@@ -23,7 +23,7 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
 }) => {
   const [selected, { error: selectedError, touched: selectedTouched }] = useField('image.selected');
   const [recommended] = useField('image.recommended');
-  const { values, setValues, setFieldTouched, validateForm } = useFormikContext<FormikValues>();
+  const { values, setValues, setFieldTouched } = useFormikContext<FormikValues>();
 
   const handleImageChange = (image: string) => {
     const newValues = {
@@ -37,7 +37,6 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
     setValues(newValues);
     setFieldTouched('image.selected', true);
     setFieldTouched('image.tag', true);
-    validateForm(newValues);
   };
 
   return (

--- a/frontend/public/extend/devconsole/components/import/git/GitSection.tsx
+++ b/frontend/public/extend/devconsole/components/import/git/GitSection.tsx
@@ -8,7 +8,7 @@ import { GitTypes } from '../import-types';
 import { detectGitType } from '../import-validation-utils';
 
 const GitSection: React.FC = () => {
-  const { values, setValues, setFieldTouched, validateForm } = useFormikContext<FormikValues>();
+  const { values, setValues, setFieldTouched } = useFormikContext<FormikValues>();
   const handleGitUrlBlur = () => {
     const gitType = detectGitType(values.git.url);
     const showGitType = gitType === '' ? true : false;
@@ -23,7 +23,6 @@ const GitSection: React.FC = () => {
     setValues(newValues);
     setFieldTouched('git.url', true);
     setFieldTouched('git.type', showGitType);
-    validateForm(newValues);
   };
 
   return (

--- a/frontend/public/extend/devconsole/components/import/import-submit-utils.ts
+++ b/frontend/public/extend/devconsole/components/import/import-submit-utils.ts
@@ -105,6 +105,7 @@ export const createDeploymentConfig = (
     project: { name: namespace },
     application: { name: application },
     image: { ports },
+    replicas,
   } = formData;
 
   const labels = getAppLabels(name, application, imageStream.metadata.name);
@@ -119,7 +120,7 @@ export const createDeploymentConfig = (
     },
     spec: {
       selector: podLabels,
-      replicas: 1,
+      replicas,
       template: {
         metadata: {
           labels: podLabels,

--- a/frontend/public/extend/devconsole/components/import/import-types.ts
+++ b/frontend/public/extend/devconsole/components/import/import-types.ts
@@ -12,6 +12,7 @@ export interface GitImportFormData {
   git: GitData;
   image: ImageData;
   route: RouteData;
+  replicas: number;
 }
 
 export interface ApplicationData {

--- a/frontend/public/extend/devconsole/components/import/import-validation-utils.ts
+++ b/frontend/public/extend/devconsole/components/import/import-validation-utils.ts
@@ -28,8 +28,13 @@ export const validationSchema = yup.object().shape({
   }),
   replicas: yup
     .number()
-    .integer()
-    .min(0, 'Replicas must be greater than or equal to 0.'),
+    .integer('Replicas must be an Integer')
+    .min(0, 'Replicas must be greater than or equal to 0.')
+    .test({
+      name: 'isEmpty',
+      test: (value) => value !== undefined,
+      message: 'This field cannot be empty',
+    }),
 });
 
 export const detectGitType = (url: string): string => {

--- a/frontend/public/extend/devconsole/components/import/import-validation-utils.ts
+++ b/frontend/public/extend/devconsole/components/import/import-validation-utils.ts
@@ -26,6 +26,10 @@ export const validationSchema = yup.object().shape({
     }),
     showGitType: yup.boolean(),
   }),
+  replicas: yup
+    .number()
+    .integer()
+    .min(0, 'Replicas must be greater than or equal to 0.'),
 });
 
 export const detectGitType = (url: string): string => {

--- a/frontend/public/extend/devconsole/components/import/scaling/ScalingSection.tsx
+++ b/frontend/public/extend/devconsole/components/import/scaling/ScalingSection.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import { FormSection } from '../section/FormSection';
+import { NumberSpinnerField } from '../../formik-fields';
+
+const ScalingSection: React.FC = () => {
+  return (
+    <FormSection
+      title="Scaling"
+      subTitle="Replicas are scaled manually based on CPU usage."
+      divider
+    >
+      <NumberSpinnerField
+        name="replicas"
+        label="Replicas"
+        helpText="The number of instances of your image."
+      />
+    </FormSection>
+  );
+};
+
+export default ScalingSection;

--- a/frontend/public/extend/devconsole/components/import/section/FormSection.tsx
+++ b/frontend/public/extend/devconsole/components/import/section/FormSection.tsx
@@ -2,16 +2,19 @@
 import * as React from 'react';
 import { FormSectionHeading } from './FormSectionHeading';
 import { FormSectionDivider } from './FormSectionDivider';
+import FormSectionSubHeading from './FormSectionSubHeading';
 
 export interface FormSectionProps {
   title: string;
+  subTitle?: string;
   divider?: boolean;
   children: React.ReactNode;
 }
 
-export const FormSection: React.FC<FormSectionProps> = ({ title, divider, children }) => (
+export const FormSection: React.FC<FormSectionProps> = ({ title, subTitle, divider, children }) => (
   <React.Fragment>
     <FormSectionHeading title={title} />
+    {subTitle && <FormSectionSubHeading subTitle={subTitle} />}
     {children}
     {divider && <FormSectionDivider />}
   </React.Fragment>

--- a/frontend/public/extend/devconsole/components/import/section/FormSectionSubHeading.tsx
+++ b/frontend/public/extend/devconsole/components/import/section/FormSectionSubHeading.tsx
@@ -1,0 +1,13 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import { HelpBlock } from 'patternfly-react';
+
+export interface FormSectionHeadingProps {
+  title: string;
+}
+
+const FormSectionSubHeading = ({ subTitle }) => (
+  <HelpBlock style={{ marginBottom: 'var(--pf-global--spacer--sm)' }}>{subTitle}</HelpBlock>
+);
+
+export default FormSectionSubHeading;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5209,17 +5209,16 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formik@2.0.1-rc.4:
-  version "2.0.1-rc.4"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.0.1-rc.4.tgz#0e282fe2dfdd03c7adf2e8a3f0720c700bc5f74e"
-  integrity sha512-YdB2CO590B2l1JWzHzAGq7SXivwj/Hn1UlWjeknbK0Nv60VKVAgAInTIHgw6qv57LbbuQRAuSy7H2rbGdIntOw==
+formik@2.0.1-rc.1:
+  version "2.0.1-rc.1"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.0.1-rc.1.tgz#5025b1731378db1c9f0560f9ba748e744854e086"
+  integrity sha512-mFIjzOtvyCPE37xWA9XSwMtMxXiieBNnQARtZpdbP2DMIzbSMcwuup9WIzeO16nNROMBqKzb+Swd47t/HOSeyA==
   dependencies:
     deepmerge "^2.1.1"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.11"
     lodash-es "^4.17.11"
     react-fast-compare "^2.0.1"
-    scheduler "^0.14.0"
     tiny-warning "^1.0.2"
     tslib "^1.9.3"
 
@@ -11574,14 +11573,6 @@ scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
   integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.14.0.tgz#b392c23c9c14bfa2933d4740ad5603cc0d59ea5b"
-  integrity sha512-9CgbS06Kki2f4R9FjLSITjZo5BZxPsryiRNyL3LpvrM9WxcVmhlqAOc9E+KQbeI2nqej4JIIbOsfdL51cNb4Iw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Related to - https://jira.coreos.com/browse/ODC-1018

This PR - 
- Create a new custom formik field that wraps `NumberSpinner`.
- Creates `FormSectionSubHeading` component and makes it optional prop in `FormSection`.
- Creates `ScalingSection` component that uses `NumberSpinnerField` and hooks into form state for replicas.
- Updates submit utils to use replicas while creating resources.
- Handles validation of replicas field.
- Downgrades formik version to 2.0.1-rc.1 because of this bug - https://github.com/jaredpalmer/formik/issues/1560

<img width="734" alt="Screenshot 2019-06-12 at 9 27 13 PM" src="https://user-images.githubusercontent.com/6041994/59367042-ec250b80-8d58-11e9-9b8f-3115d98671e7.png">
<img width="724" alt="Screenshot 2019-06-12 at 9 27 27 PM" src="https://user-images.githubusercontent.com/6041994/59367043-ecbda200-8d58-11e9-9341-a933583a9fcd.png">
